### PR TITLE
Removes last session_path usage from StateHandler class

### DIFF
--- a/src/OpenConext/ProfileBundle/Saml/StateHandler.php
+++ b/src/OpenConext/ProfileBundle/Saml/StateHandler.php
@@ -63,7 +63,7 @@ class StateHandler
      */
     public function hasRequestId()
     {
-        return $this->attributeBag->has(self::SESSION_PATH . 'request_id');
+        return $this->attributeBag->has('request_id');
     }
 
     /**


### PR DESCRIPTION
Probably missed this because my session was already loaded.