### PR TITLE
Configure PHP-FPM to run on boot

### DIFF
--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -49,4 +49,6 @@
   action: template src='php-fpm-pool.conf.j2' dest='/etc/php-fpm.d/{{ server.name }}.conf' owner=nginx group=nginx
   notify: Restart php-fpm
 
+- name: Configure PHP-FPM to run on boot
+  command: chkconfig php-fpm on
 


### PR DESCRIPTION
[Bugfix, ticket 106924668](https://www.pivotaltracker.com/story/show/106924668)

Apparently, a startup script is not setup automatically by PHP-FPM. Chkconfig allows us to do so.
More info on [chkconfig](http://linux.die.net/man/8/chkconfig):
> chkconfig provides a simple command-line tool for maintaining the /etc/rc[0-6].d directory hierarchy by relieving system administrators of the task of directly manipulating the numerous symbolic links in those directories.

> (...)

>   If one of on, off, reset, or resetpriorities is specified after the service name, chkconfig changes the startup information for the specified service.

> (...)