### PR TITLE
Uses service instead of command to start php-fpm on boot

### DIFF
--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -50,5 +50,4 @@
   notify: Restart php-fpm
 
 - name: Configure PHP-FPM to run on boot
-  command: chkconfig php-fpm on
-
+  service: name=php-fpm enabled=yes


### PR DESCRIPTION
[Ticket 106924668](https://www.pivotaltracker.com/story/show/106924668)

Improves #11 by using Ansible's (abstracted) service module instead of chkconfig.