### PR TITLE
Retrieve consent type

### DIFF
--- a/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
@@ -35,7 +35,7 @@ final class ConsentListFactoryTest extends TestCase
 {
     /**
      * @test
-     * @group consent
+     * @group Consent
      */
     public function it_can_create_a_consent_list()
     {

--- a/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
@@ -23,6 +23,7 @@ use OpenConext\EngineBlockApiClientBundle\Value\ConsentListFactory;
 use OpenConext\Profile\Value\Consent;
 use OpenConext\Profile\Value\Consent\ServiceProvider;
 use OpenConext\Profile\Value\ConsentList;
+use OpenConext\Profile\Value\ConsentType;
 use OpenConext\Profile\Value\DisplayName;
 use OpenConext\Profile\Value\EmailAddress;
 use OpenConext\Profile\Value\Entity;
@@ -44,6 +45,11 @@ final class ConsentListFactoryTest extends TestCase
         $firstEula          = 'https://domain.invalid';
         $secondSupportEmail = 'support@openconext.org';
 
+        $givenFirstConsentTypeValue = 'explicit';
+        $expectedFirstConsentType = ConsentType::explicit();
+        $givenSecondConsentTypeValue = 'implicit';
+        $expectedSecondConsentType = ConsentType::implicit();
+
         $given = [
             [
                 'service_provider' => [
@@ -54,6 +60,7 @@ final class ConsentListFactoryTest extends TestCase
                 ],
                 'consent_given_on' => '2015-11-05T08:43:01+01:00',
                 'last_used_on'     => '2015-11-05T08:43:01+01:00',
+                'consent_type'     => $givenFirstConsentTypeValue
             ],
             [
                 'service_provider' => [
@@ -64,6 +71,7 @@ final class ConsentListFactoryTest extends TestCase
                 ],
                 'consent_given_on' => '2015-11-05T08:17:04+01:00',
                 'last_used_on'     => '2015-11-05T08:17:04+01:00',
+                'consent_type'     => $givenSecondConsentTypeValue
             ],
         ];
 
@@ -76,7 +84,8 @@ final class ConsentListFactoryTest extends TestCase
                     null
                 ),
                 new DateTimeImmutable('2015-11-05T08:43:01+01:00'),
-                new DateTimeImmutable('2015-11-05T08:43:01+01:00')
+                new DateTimeImmutable('2015-11-05T08:43:01+01:00'),
+                $expectedFirstConsentType
             ),
             new Consent(
                 new ServiceProvider(
@@ -86,7 +95,8 @@ final class ConsentListFactoryTest extends TestCase
                     new EmailAddress($secondSupportEmail)
                 ),
                 new DateTimeImmutable('2015-11-05T08:17:04+01:00'),
-                new DateTimeImmutable('2015-11-05T08:17:04+01:00')
+                new DateTimeImmutable('2015-11-05T08:17:04+01:00'),
+                $expectedSecondConsentType
             ),
         ]);
 

--- a/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
@@ -32,6 +32,9 @@ use OpenConext\Profile\Value\EntityId;
 use OpenConext\Profile\Value\EntityType;
 use OpenConext\Profile\Value\Url;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 final class ConsentListFactory
 {
     /**

--- a/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
@@ -89,7 +89,7 @@ final class ConsentListFactory
 
         if ($data['consent_type'] === ConsentType::TYPE_EXPLICIT) {
             $consentType = ConsentType::explicit();
-        } else if ($data['consent_type'] === ConsentType::TYPE_IMPLICIT) {
+        } else {
             $consentType = ConsentType::implicit();
         }
 

--- a/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
@@ -24,6 +24,7 @@ use OpenConext\Profile\Assert;
 use OpenConext\Profile\Value\Consent;
 use OpenConext\Profile\Value\Consent\ServiceProvider;
 use OpenConext\Profile\Value\ConsentList;
+use OpenConext\Profile\Value\ConsentType;
 use OpenConext\Profile\Value\DisplayName;
 use OpenConext\Profile\Value\EmailAddress;
 use OpenConext\Profile\Value\Entity;
@@ -55,6 +56,13 @@ final class ConsentListFactory
         Assert::keyExists($data, 'service_provider', 'Consent JSON structure must contain key "service_provider"');
         Assert::keyExists($data, 'consent_given_on', 'Consent JSON structure must contain key "consent_given_on"');
         Assert::keyExists($data, 'last_used_on', 'Consent JSON structure must contain key "last_used_on"');
+        Assert::keyExists($data, 'consent_type', 'Consent JSON structure must contain key "consent_type"');
+
+        Assert::choice(
+            $data['consent_type'],
+            [ConsentType::TYPE_EXPLICIT, ConsentType::TYPE_IMPLICIT],
+            '"%s" is not one of the valid ConsentTypes: %s'
+        );
 
         $consentGivenOn = DateTimeImmutable::createFromFormat(DateTime::ATOM, $data['consent_given_on']);
         $lastUsedOn = DateTimeImmutable::createFromFormat(DateTime::ATOM, $data['last_used_on']);
@@ -76,10 +84,17 @@ final class ConsentListFactory
             )
         );
 
+        if ($data['consent_type'] === ConsentType::TYPE_EXPLICIT) {
+            $consentType = ConsentType::explicit();
+        } else if ($data['consent_type'] === ConsentType::TYPE_IMPLICIT) {
+            $consentType = ConsentType::implicit();
+        }
+
         return new Consent(
             self::createServiceProvider($data['service_provider']),
             $consentGivenOn,
-            $lastUsedOn
+            $lastUsedOn,
+            $consentType
         );
     }
 

--- a/src/OpenConext/Profile/Tests/Value/ConsentTypeTest.php
+++ b/src/OpenConext/Profile/Tests/Value/ConsentTypeTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Copyright 2015 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\Profile\Tests\Value;
+
+use OpenConext\Profile\Value\ConsentType;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class ConsentTypeTest extends TestCase
+{
+    /**
+     * @test
+     * @group Consent
+     * @group Value
+     */
+    public function different_consent_types_are_not_equal()
+    {
+        $explicit = ConsentType::explicit();
+        $implicit = ConsentType::implicit();
+
+        $this->assertFalse($explicit->equals($implicit));
+        $this->assertFalse($implicit->equals($explicit));
+    }
+
+    /**
+     * @test
+     * @group Consent
+     * @group Value
+     */
+    public function same_type_of_consent_types_are_equal()
+    {
+        $explicit = ConsentType::explicit();
+        $implicit = ConsentType::implicit();
+
+        $this->assertTrue($explicit->equals(ConsentType::explicit()));
+        $this->assertTrue($implicit->equals(ConsentType::implicit()));
+    }
+}

--- a/src/OpenConext/Profile/Tests/Value/EmailAddressTest.php
+++ b/src/OpenConext/Profile/Tests/Value/EmailAddressTest.php
@@ -28,7 +28,7 @@ final class EmailAddressTest extends TestCase
 
     /**
      * @test
-     * @group value
+     * @group Value
      */
     public function it_accepts_emails()
     {

--- a/src/OpenConext/Profile/Tests/Value/EntityIdTest.php
+++ b/src/OpenConext/Profile/Tests/Value/EntityIdTest.php
@@ -28,7 +28,7 @@ class EntityIdTest extends UnitTest
 
     /**
      * @test
-     * @group EntityVerificationFramework
+     * @group Entity
      * @group Value
      *
      * @dataProvider notNonEmptyOrBlankStringProvider
@@ -43,7 +43,7 @@ class EntityIdTest extends UnitTest
 
     /**
      * @test
-     * @group EntityVerificationFramework
+     * @group Entity
      * @group Value
      */
     public function the_same_entity_ids_are_considered_equal()

--- a/src/OpenConext/Profile/Tests/Value/EntityTest.php
+++ b/src/OpenConext/Profile/Tests/Value/EntityTest.php
@@ -27,7 +27,7 @@ class EntityTest extends UnitTest
 {
     /**
      * @test
-     * @group EntityVerificationFramework
+     * @group Entity
      * @group Value
      */
     public function two_entities_with_the_same_entity_id_and_entity_type_are_equal()

--- a/src/OpenConext/Profile/Tests/Value/EntityTypeTest.php
+++ b/src/OpenConext/Profile/Tests/Value/EntityTypeTest.php
@@ -25,7 +25,7 @@ class EntityTypeTest extends UnitTest
 {
     /**
      * @test
-     * @group EntityVerificationFramework
+     * @group Entity
      * @group Value
      */
     public function the_same_entity_types_are_considered_equal()

--- a/src/OpenConext/Profile/Tests/Value/UrlTest.php
+++ b/src/OpenConext/Profile/Tests/Value/UrlTest.php
@@ -28,7 +28,7 @@ class UrlTest extends TestCase
 
     /**
      * @test
-     * @group value
+     * @group Value
      */
     public function one_can_be_created_with_a_valid_url()
     {

--- a/src/OpenConext/Profile/Value/Consent.php
+++ b/src/OpenConext/Profile/Value/Consent.php
@@ -42,18 +42,26 @@ final class Consent
     private $lastUsedOn;
 
     /**
+     * @var ConsentType
+     */
+    private $consentType;
+
+    /**
      * @param ServiceProvider $serviceProvider
      * @param DateTimeImmutable $consentGivenOn
      * @param DateTimeImmutable $lastUsedOn
+     * @param ConsentType $consentType
      */
     public function __construct(
         ServiceProvider $serviceProvider,
         DateTimeImmutable $consentGivenOn,
-        DateTimeImmutable $lastUsedOn
+        DateTimeImmutable $lastUsedOn,
+        ConsentType $consentType
     ) {
         $this->serviceProvider = $serviceProvider;
         $this->consentGivenOn  = $consentGivenOn;
         $this->lastUsedOn      = $lastUsedOn;
+        $this->consentType     = $consentType;
     }
 
     /**
@@ -78,5 +86,13 @@ final class Consent
     public function getLastUsedOn()
     {
         return $this->lastUsedOn;
+    }
+
+    /**
+     * @return ConsentType
+     */
+    public function getConsentType()
+    {
+        return $this->consentType;
     }
 }

--- a/src/OpenConext/Profile/Value/ConsentType.php
+++ b/src/OpenConext/Profile/Value/ConsentType.php
@@ -1,8 +1,79 @@
 <?php
 
+/**
+ * Copyright 2015 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace OpenConext\Profile\Value;
 
-class ConsentType
-{
+use OpenConext\Profile\Assert;
 
+final class ConsentType
+{
+    const TYPE_EXPLICIT = 'explicit';
+    const TYPE_IMPLICIT = 'implicit';
+
+    /**
+     * @var ConsentType
+     */
+    private $consentType;
+
+    /**
+     * @return ConsentType
+     */
+    public static function explicit()
+    {
+        return new self(self::TYPE_EXPLICIT);
+    }
+
+    /**
+     * @return ConsentType
+     */
+    public static function implicit()
+    {
+        return new self(self::TYPE_IMPLICIT);
+    }
+
+    /**
+     * @param string $consentType
+     */
+    private function __construct($consentType)
+    {
+        Assert::choice(
+            $consentType,
+            [ConsentType::TYPE_EXPLICIT, ConsentType::TYPE_IMPLICIT],
+            '"%s" is not one of the valid ConsentTypes: %s'
+        );
+
+        $this->consentType = $consentType;
+    }
+
+    /**
+     * @param ConsentType $other
+     * @return bool
+     */
+    public function equals(ConsentType $other)
+    {
+        return $this->consentType === $other->consentType;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->consentType;
+    }
 }

--- a/src/OpenConext/Profile/Value/ConsentType.php
+++ b/src/OpenConext/Profile/Value/ConsentType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenConext\Profile\Value;
+
+class ConsentType
+{
+
+}


### PR DESCRIPTION
[Ticket 106401530](https://www.pivotaltracker.com/story/show/106401530)

In order to show the consent type on the services page, it is added to the consent object.

Blocked by: [PR EB #219](https://github.com/OpenConext/OpenConext-engineblock/pull/219)