### PR TITLE
Removes unused session in StateHandler

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/config/services.yml
+++ b/src/OpenConext/ProfileBundle/Resources/config/services.yml
@@ -59,7 +59,6 @@ services:
         class: OpenConext\ProfileBundle\Saml\StateHandler
         arguments:
             - @profile.session
-            - @session
 
     profile.session:
         class: Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag

--- a/src/OpenConext/ProfileBundle/Saml/StateHandler.php
+++ b/src/OpenConext/ProfileBundle/Saml/StateHandler.php
@@ -28,15 +28,9 @@ class StateHandler
      */
     private $attributeBag;
 
-    /**
-     * @var SessionInterface
-     */
-    private $session;
-
-    public function __construct(NamespacedAttributeBag $attributeBag, SessionInterface $session)
+    public function __construct(NamespacedAttributeBag $attributeBag)
     {
         $this->attributeBag = $attributeBag;
-        $this->session = $session;
     }
 
     /**

--- a/src/OpenConext/ProfileBundle/Saml/StateHandler.php
+++ b/src/OpenConext/ProfileBundle/Saml/StateHandler.php
@@ -19,7 +19,6 @@
 namespace OpenConext\ProfileBundle\Saml;
 
 use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class StateHandler
 {


### PR DESCRIPTION
When removing the session migration from the Saml StateHandler, the session object itself has not been removed. This PR cleans that up.