### PR TITLE
Restyle attributes in services table

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -238,6 +238,20 @@ tr.service:hover {
     margin-top: 32px;
 }
 
+.service-attributes table,
+.service-attributes table thead tr:hover {
+    background-color: #f3f3f3;
+    border: none;
+}
+.service-attributes table td,
+.service-attributes table th {
+    font-size: 14px;
+}
+.service-attributes table td {
+    border-top-color: #ffffff;
+    border-bottom-color: #ffffff;
+}
+
 /* Footer */
 .footer {
     border-top: 1px solid #cccccc;


### PR DESCRIPTION
[Ticket 109071222](https://www.pivotaltracker.com/story/show/109071222)

Makes table look more like older version with smaller fonts and a darker background.
Also prevents table head from getting highlighted.

![restyled inline attributes](https://cloud.githubusercontent.com/assets/3816591/12016608/85d45442-ad4d-11e5-9cf9-975a6e991144.png)

*Possible merge conflicts with other PRs*