### PR TITLE
Drop setting HSTS header

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -50,6 +50,8 @@ nelmio_security:
     xss_protection:
         enabled: true
         mode_block: true
+    forced_ssl:
+        enabled: true
 
 monolog:
     handlers:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -50,9 +50,6 @@ nelmio_security:
     xss_protection:
         enabled: true
         mode_block: true
-    forced_ssl:
-        hsts_max_age: 2592000 # 30 days
-        hsts_subdomains: true
 
 monolog:
     handlers:


### PR DESCRIPTION
This should be configured on the server level in production, see OpenConext-Deploy

#54 