### PR TITLE
Implement attribute set with fallbacks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "sensio/distribution-bundle": "~4.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "~2.0",
-        "surfnet/stepup-saml-bundle": "^2.6",
+        "surfnet/stepup-saml-bundle": "^2.6.1",
         "jms/translation-bundle": "^1.1",
         "jms/di-extra-bundle": "^1.1",
         "twig/extensions": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "sensio/distribution-bundle": "~4.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "~2.0",
-        "surfnet/stepup-saml-bundle": "^2.4",
+        "surfnet/stepup-saml-bundle": "^2.6",
         "jms/translation-bundle": "^1.1",
         "jms/di-extra-bundle": "^1.1",
         "twig/extensions": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f190eac10b0ebed5c4f82b69c293c1b6",
-    "content-hash": "c00d02be913d45cf81b27532da036c55",
+    "hash": "a5426c3b94f151300f41480373566522",
+    "content-hash": "c79455249650eec3fbe0ea2943ef3145",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1555,16 +1555,16 @@
         },
         {
             "name": "surfnet/stepup-saml-bundle",
-            "version": "2.6.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SURFnet/Stepup-saml-bundle.git",
-                "reference": "86ee2879a0f87e6aa31f001c212cd4d50d54d23f"
+                "reference": "cfc4cc7d13186f24d8ef332f59cc23514f654158"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/86ee2879a0f87e6aa31f001c212cd4d50d54d23f",
-                "reference": "86ee2879a0f87e6aa31f001c212cd4d50d54d23f",
+                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/cfc4cc7d13186f24d8ef332f59cc23514f654158",
+                "reference": "cfc4cc7d13186f24d8ef332f59cc23514f654158",
                 "shasum": ""
             },
             "require": {
@@ -1599,7 +1599,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2016-10-19 12:00:52"
+            "time": "2016-10-19 14:30:38"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ce60ba12b8759cbf0a5715da62810ec8",
-    "content-hash": "5db746de023b881d18b4ca1addb2df57",
+    "hash": "f190eac10b0ebed5c4f82b69c293c1b6",
+    "content-hash": "c00d02be913d45cf81b27532da036c55",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1555,16 +1555,16 @@
         },
         {
             "name": "surfnet/stepup-saml-bundle",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SURFnet/Stepup-saml-bundle.git",
-                "reference": "3ee050d16f76bf63b48fa01af3e75e1b42668d72"
+                "reference": "86ee2879a0f87e6aa31f001c212cd4d50d54d23f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/3ee050d16f76bf63b48fa01af3e75e1b42668d72",
-                "reference": "3ee050d16f76bf63b48fa01af3e75e1b42668d72",
+                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/86ee2879a0f87e6aa31f001c212cd4d50d54d23f",
+                "reference": "86ee2879a0f87e6aa31f001c212cd4d50d54d23f",
                 "shasum": ""
             },
             "require": {
@@ -1599,7 +1599,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2016-07-01 09:33:44"
+            "time": "2016-10-19 12:00:52"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/OpenConext/Profile/Entity/AuthenticatedUser.php
+++ b/src/OpenConext/Profile/Entity/AuthenticatedUser.php
@@ -19,11 +19,11 @@
 namespace OpenConext\Profile\Entity;
 
 use OpenConext\Profile\Assert;
-use OpenConext\Profile\Exception\InvalidEptiAttributeException;
 use OpenConext\Profile\Exception\RuntimeException;
 use OpenConext\Profile\Value\EntityId;
 use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetInterface;
 use Surfnet\SamlBundle\SAML2\Response\AssertionAdapter;
 
 final class AuthenticatedUser
@@ -34,7 +34,7 @@ final class AuthenticatedUser
     private $nameId;
 
     /**
-     * @var AttributeSet
+     * @var AttributeSetInterface
      */
     private $attributes;
 

--- a/src/OpenConext/Profile/Entity/AuthenticatedUser.php
+++ b/src/OpenConext/Profile/Entity/AuthenticatedUser.php
@@ -23,7 +23,6 @@ use OpenConext\Profile\Exception\RuntimeException;
 use OpenConext\Profile\Value\EntityId;
 use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
-use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetInterface;
 use Surfnet\SamlBundle\SAML2\Response\AssertionAdapter;
 
 final class AuthenticatedUser
@@ -34,7 +33,7 @@ final class AuthenticatedUser
     private $nameId;
 
     /**
-     * @var AttributeSetInterface
+     * @var AttributeSet
      */
     private $attributes;
 

--- a/src/OpenConext/ProfileBundle/Attribute/AttributeSetWithFallbacks.php
+++ b/src/OpenConext/ProfileBundle/Attribute/AttributeSetWithFallbacks.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\ProfileBundle\Attribute;
+
+use SAML2_Assertion;
+use Surfnet\SamlBundle\Exception\UnknownUrnException;
+use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetFactory;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetInterface;
+
+final class AttributeSetWithFallbacks extends AttributeSet implements AttributeSetFactory, AttributeSetInterface
+{
+    public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
+    {
+        $attributeSet = new AttributeSetWithFallbacks();
+
+        foreach ($assertion->getAttributes() as $urn => $attributeValue) {
+            try {
+                $attributeDefinition = $attributeDictionary->getAttributeDefinitionByUrn($urn);
+            } catch (UnknownUrnException $exception) {
+                $attributeDefinition = new AttributeDefinition($urn, $urn, $urn);
+            }
+
+            $attributeSet->initializeWith(new Attribute($attributeDefinition, $attributeValue));
+        }
+
+        return $attributeSet;
+    }
+
+    public static function create(array $attributes)
+    {
+        $attributeSet = new AttributeSetWithFallbacks();
+
+        foreach ($attributes as $attribute) {
+            $attributeSet->initializeWith($attribute);
+        }
+
+        return $attributeSet;
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
@@ -76,7 +76,13 @@
                                     {% endif %}
                                     <tr>
                                         <td title="{{ attributeUrn }}">
-                                            <strong>{{ ('profile.saml.attributes.' ~ attribute.attributeDefinition.name)|trans({}, 'saml') }}</strong>
+                                            {% set translatedAttribute = ('profile.saml.attributes.' ~ attribute.attributeDefinition.name)|trans({}, 'saml') %}
+
+                                            {% if translatedAttribute == 'profile.saml.attributes.' ~ attribute.attributeDefinition.name %}
+                                                <strong>{{ attributeUrn }}</strong>
+                                            {% else %}
+                                                <strong>{{ translatedAttribute }}</strong>
+                                            {% endif %}
                                         </td>
                                         <td>
                                             {% if attribute.value is iterable %}

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
@@ -76,12 +76,12 @@
                                     {% endif %}
                                     <tr>
                                         <td title="{{ attributeUrn }}">
-                                            {% set translatedAttribute = ('profile.saml.attributes.' ~ attribute.attributeDefinition.name)|trans({}, 'saml') %}
+                                            {% set translatedAttributeName = ('profile.saml.attributes.' ~ attribute.attributeDefinition.name)|trans({}, 'saml') %}
 
-                                            {% if translatedAttribute == 'profile.saml.attributes.' ~ attribute.attributeDefinition.name %}
+                                            {% if translatedAttributeName == 'profile.saml.attributes.' ~ attribute.attributeDefinition.name %}
                                                 <strong>{{ attributeUrn }}</strong>
                                             {% else %}
-                                                <strong>{{ translatedAttribute }}</strong>
+                                                <strong>{{ translatedAttributeName }}</strong>
                                             {% endif %}
                                         </td>
                                         <td>

--- a/src/OpenConext/ProfileBundle/Security/Authentication/Provider/SamlProvider.php
+++ b/src/OpenConext/ProfileBundle/Security/Authentication/Provider/SamlProvider.php
@@ -20,8 +20,12 @@ namespace OpenConext\ProfileBundle\Security\Authentication\Provider;
 
 use OpenConext\Profile\Entity\AuthenticatedUser;
 use OpenConext\Profile\Value\EntityId;
+use OpenConext\ProfileBundle\Attribute\AttributeSetWithFallbacks;
 use OpenConext\ProfileBundle\Security\Authentication\Token\SamlToken;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetFactory;
+use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -39,6 +43,7 @@ class SamlProvider implements AuthenticationProviderInterface
 
     public function authenticate(TokenInterface $token)
     {
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(AttributeSetWithFallbacks::class);
         $translatedAssertion = $this->attributeDictionary->translate($token->assertion);
 
         $authenticatingAuthorities = array_map(

--- a/src/OpenConext/ProfileBundle/Tests/Attribute/AttributeSetWithFallbacksTest.php
+++ b/src/OpenConext/ProfileBundle/Tests/Attribute/AttributeSetWithFallbacksTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\ProfileBundle\Tests\Attribute;
+
+use Mockery;
+use OpenConext\ProfileBundle\Attribute\AttributeSetWithFallbacks;
+use PHPUnit_Framework_TestCase as TestCase;
+use SAML2_Assertion;
+use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
+use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
+use Surfnet\SamlBundle\SAML2\Response\AssertionAdapter;
+
+class AttributeSetWithFallbacksTest extends TestCase
+{
+    /**
+     * @test
+     * @group AttributeSet
+     * @group AttributeDictionary
+     * @group AssertionAdapter
+     */
+    public function attribute_set_with_fallbacks_can_be_configured_when_creating_an_assertion_adapter()
+    {
+        $assertion = Mockery::mock(SAML2_Assertion::class);
+        $assertion
+            ->shouldReceive('getAttributes')
+            ->andReturn([]);
+
+        $dictionary = new AttributeDictionary();
+
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(AttributeSetWithFallbacks::class);
+
+        $adapter          = new AssertionAdapter($assertion, $dictionary);
+        $attributeSet     = $adapter->getAttributeSet();
+
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(AttributeSet::class);
+
+        $this->assertInstanceOf(AttributeSetWithFallbacks::class, $attributeSet);
+    }
+
+    /**
+     * @test
+     * @group AttributeSet
+     * @group AttributeDictionary
+     */
+    public function attribute_set_with_fallbacks_contains_an_attribute_with_an_existing_definition()
+    {
+        $attributeMaceUrn = 'urn:mace:some-attribute';
+        $attributeValue   = ['someValue'];
+
+        $attributeDefinition = new AttributeDefinition('some-attribute', $attributeMaceUrn);
+
+        $assertion = Mockery::mock(SAML2_Assertion::class);
+        $assertion
+            ->shouldReceive('getAttributes')
+            ->andReturn([
+                $attributeMaceUrn => $attributeValue
+            ]);
+
+        $dictionary = new AttributeDictionary();
+        $dictionary->addAttributeDefinition($attributeDefinition);
+
+        $attributeSet = AttributeSetWithFallbacks::createFrom($assertion, $dictionary);
+
+        $attributeIsInSet = $attributeSet->contains(new Attribute($attributeDefinition, $attributeValue));
+
+        $this->assertTrue($attributeIsInSet);
+    }
+
+
+    /**
+     * @test
+     * @group AttributeSet
+     * @group AttributeDictionary
+     */
+    public function attribute_set_with_fallbacks_falls_back_to_the_the_received_urn_when_encountering_an_undefined_attribute(
+    )
+    {
+        $undefinedAttributeUrn = 'urn:mace:not-defined';
+        $attributeValue        = ['some-value'];
+
+        $assertion = Mockery::mock(SAML2_Assertion::class);
+        $assertion
+            ->shouldReceive('getAttributes')
+            ->andReturn([
+                $undefinedAttributeUrn => $attributeValue
+            ]);
+        $dictionary = new AttributeDictionary();
+
+        $attributeSet = AttributeSetWithFallbacks::createFrom($assertion, $dictionary);
+
+        $expectedAttribute = new Attribute(
+            new AttributeDefinition(
+                $undefinedAttributeUrn,
+                $undefinedAttributeUrn,
+                $undefinedAttributeUrn
+            ),
+            $attributeValue
+        );
+
+        $attributeIsInSet = $attributeSet->contains($expectedAttribute);
+
+        $this->assertTrue($attributeIsInSet);
+    }
+}


### PR DESCRIPTION
This implements #55 in Profile, using the ConfigurableAttributeSetFactory from SURFnet/Stepup-saml-bundle#51.

As shown in the image below, an undefined attribute will use its urn as a name in the My Services table (in this case I removed the definition for the "surfconext status" for testing purposes). It will not throw an exception.
<img width="666" alt="screen shot 2016-10-19 at 14 56 03" src="https://cloud.githubusercontent.com/assets/3816591/19519759/8f98407a-960d-11e6-8201-71c551b44fc4.png">

