### PR TITLE
Remove translation key from undefined attributes

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig
@@ -51,7 +51,13 @@
                 {% endif %}
                 <tr>
                     <td title="{{ attributeUrn }}">
-                        <strong>{{ ('profile.saml.attributes.' ~ attribute.attributeDefinition.name)|trans({}, 'saml') }}</strong>
+                        {% set translatedAttributeName = ('profile.saml.attributes.' ~ attribute.attributeDefinition.name)|trans({}, 'saml') %}
+
+                        {% if translatedAttributeName == 'profile.saml.attributes.' ~ attribute.attributeDefinition.name %}
+                            <strong>{{ attributeUrn }}</strong>
+                        {% else %}
+                            <strong>{{ translatedAttributeName }}</strong>
+                        {% endif %}
                     </td>
                     <td>
                         {% if attribute.value is iterable %}


### PR DESCRIPTION
This has already been done in the [My Services template](https://github.com/OpenConext/OpenConext-profile/blob/d6a0ede4a93203823efe631fc993c230a51d6637/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig#L79-L85).