### PR TITLE
Support fallbacks for attribute definitions in ARP service

### DIFF
--- a/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
@@ -54,7 +54,7 @@ final class AttributeReleasePolicyService
      * @param ConsentList $consentList
      * @param AttributeSetInterface $attributeSet
      * @return SpecifiedConsentList
-     * @SuppressWarnings(PHPMD.NPathComplexity) Build and mapping logic causes complexity
+     * @SuppressWarnings(PHPMD.NPathComplexity, PHPMD.CouplingBetweenObjects) Build and mapping logic causes complexity
      */
     public function applyAttributeReleasePolicies(ConsentList $consentList, AttributeSetInterface $attributeSet)
     {

--- a/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
@@ -32,6 +32,9 @@ use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Build and mapping logic causes complexity
+ */
 final class AttributeReleasePolicyService
 {
     /**
@@ -55,7 +58,6 @@ final class AttributeReleasePolicyService
      * @param AttributeSetInterface $attributeSet
      * @return SpecifiedConsentList
      * @SuppressWarnings(PHPMD.NPathComplexity) Build and mapping logic causes complexity
-     * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Build and mapping logic causes complexity
      */
     public function applyAttributeReleasePolicies(ConsentList $consentList, AttributeSetInterface $attributeSet)
     {

--- a/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
@@ -54,7 +54,8 @@ final class AttributeReleasePolicyService
      * @param ConsentList $consentList
      * @param AttributeSetInterface $attributeSet
      * @return SpecifiedConsentList
-     * @SuppressWarnings(PHPMD.NPathComplexity, PHPMD.CouplingBetweenObjects) Build and mapping logic causes complexity
+     * @SuppressWarnings(PHPMD.NPathComplexity) Build and mapping logic causes complexity
+     * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Build and mapping logic causes complexity
      */
     public function applyAttributeReleasePolicies(ConsentList $consentList, AttributeSetInterface $attributeSet)
     {


### PR DESCRIPTION
Because we do not have any guarantees the definitions are to be found in the dictionary, we apply the same fallback mechanism as used in the AttributeSetWithFallbacks.