### PR TITLE
Switch last used with first used consent date

### DIFF
--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -240,11 +240,6 @@ This profile page gives you insight in which personal data, provided by your ins
         <target>This service receives the following information about you:</target>
         <jms:reference-file line="65">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="3bafef555140350349fa9fdb0ffecad23694a736" resname="profile.my_services.consent_last_used_on">
-        <source>profile.my_services.consent_last_used_on</source>
-        <target>Last used on</target>
-        <jms:reference-file line="55">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
         <source>profile.my_services.consent_first_used_on</source>
         <target>First used on</target>

--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -245,6 +245,11 @@ This profile page gives you insight in which personal data, provided by your ins
         <target>Last used on</target>
         <jms:reference-file line="55">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
+        <source>profile.my_services.consent_first_used_on</source>
+        <target>First used on</target>
+        <jms:reference-file line="55">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="927d4519f4715517225aa5df22bf583e6421a0cf" resname="profile.my_services.consent_type">
         <source>profile.my_services.consent_type</source>
         <target>Consent was given by</target>

--- a/app/Resources/translations/messages.nl.xliff
+++ b/app/Resources/translations/messages.nl.xliff
@@ -240,11 +240,6 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
         <target>Deze dienst ontvangt de volgende gegevens over jou:</target>
         <jms:reference-file line="65">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="3bafef555140350349fa9fdb0ffecad23694a736" resname="profile.my_services.consent_last_used_on">
-        <source>profile.my_services.consent_last_used_on</source>
-        <target>Voor het laatst gebruikt op</target>
-        <jms:reference-file line="55">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
         <source>profile.my_services.consent_first_used_on</source>
         <target>Voor het eerst gebruikt op</target>

--- a/app/Resources/translations/messages.nl.xliff
+++ b/app/Resources/translations/messages.nl.xliff
@@ -245,6 +245,11 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
         <target>Voor het laatst gebruikt op</target>
         <jms:reference-file line="55">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
+        <source>profile.my_services.consent_first_used_on</source>
+        <target>Voor het eerst gebruikt op</target>
+        <jms:reference-file line="55">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="927d4519f4715517225aa5df22bf583e6421a0cf" resname="profile.my_services.consent_type">
         <source>profile.my_services.consent_type</source>
         <target>Toestemming gegeven door</target>

--- a/composer.lock
+++ b/composer.lock
@@ -1506,16 +1506,16 @@
         },
         {
             "name": "simplesamlphp/saml2",
-            "version": "v1.10",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "6a4b1eece19b067b17fff718176689b82dc89fb9"
+                "reference": "3f268c25ca5e9748652834faad04525746227ef7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/6a4b1eece19b067b17fff718176689b82dc89fb9",
-                "reference": "6a4b1eece19b067b17fff718176689b82dc89fb9",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/3f268c25ca5e9748652834faad04525746227ef7",
+                "reference": "3f268c25ca5e9748652834faad04525746227ef7",
                 "shasum": ""
             },
             "require": {
@@ -1551,20 +1551,20 @@
                 }
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
-            "time": "2016-09-15 06:14:20"
+            "time": "2016-12-02 12:15:53"
         },
         {
             "name": "surfnet/stepup-saml-bundle",
-            "version": "2.6.1",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SURFnet/Stepup-saml-bundle.git",
-                "reference": "cfc4cc7d13186f24d8ef332f59cc23514f654158"
+                "reference": "2c1e4c084d790f49e867a4c33463b2da872a4182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/cfc4cc7d13186f24d8ef332f59cc23514f654158",
-                "reference": "cfc4cc7d13186f24d8ef332f59cc23514f654158",
+                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/2c1e4c084d790f49e867a4c33463b2da872a4182",
+                "reference": "2c1e4c084d790f49e867a4c33463b2da872a4182",
                 "shasum": ""
             },
             "require": {
@@ -1599,7 +1599,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2016-10-19 14:30:38"
+            "time": "2016-12-12 12:31:10"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
@@ -59,7 +59,6 @@ final class ConsentListFactoryTest extends TestCase
                     'support_email' => null,
                 ],
                 'consent_given_on' => '2015-11-05T08:43:01+01:00',
-                'last_used_on'     => '2015-11-05T08:43:01+01:00',
                 'consent_type'     => $givenFirstConsentTypeValue
             ],
             [
@@ -70,7 +69,6 @@ final class ConsentListFactoryTest extends TestCase
                     'support_email' => $secondSupportEmail,
                 ],
                 'consent_given_on' => '2015-11-05T08:17:04+01:00',
-                'last_used_on'     => '2015-11-05T08:17:04+01:00',
                 'consent_type'     => $givenSecondConsentTypeValue
             ],
         ];
@@ -84,7 +82,6 @@ final class ConsentListFactoryTest extends TestCase
                     null
                 ),
                 new DateTimeImmutable('2015-11-05T08:43:01+01:00'),
-                new DateTimeImmutable('2015-11-05T08:43:01+01:00'),
                 $expectedFirstConsentType
             ),
             new Consent(
@@ -94,7 +91,6 @@ final class ConsentListFactoryTest extends TestCase
                     null,
                     new ContactEmailAddress($secondSupportEmail)
                 ),
-                new DateTimeImmutable('2015-11-05T08:17:04+01:00'),
                 new DateTimeImmutable('2015-11-05T08:17:04+01:00'),
                 $expectedSecondConsentType
             ),

--- a/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
@@ -64,7 +64,6 @@ final class ConsentListFactory
     {
         Assert::keyExists($data, 'service_provider', 'Consent JSON structure must contain key "service_provider"');
         Assert::keyExists($data, 'consent_given_on', 'Consent JSON structure must contain key "consent_given_on"');
-        Assert::keyExists($data, 'last_used_on', 'Consent JSON structure must contain key "last_used_on"');
         Assert::keyExists($data, 'consent_type', 'Consent JSON structure must contain key "consent_type"');
 
         Assert::choice(
@@ -74,7 +73,6 @@ final class ConsentListFactory
         );
 
         $consentGivenOn = DateTimeImmutable::createFromFormat(DateTime::ATOM, $data['consent_given_on']);
-        $lastUsedOn = DateTimeImmutable::createFromFormat(DateTime::ATOM, $data['last_used_on']);
 
         Assert::isInstanceOf(
             $consentGivenOn,
@@ -83,15 +81,6 @@ final class ConsentListFactory
             sprintf(
                 'Consent given on date must be formatted according to the ISO8601 standard, got "%s"',
                 $data['consent_given_on']
-            )
-        );
-        Assert::isInstanceOf(
-            $lastUsedOn,
-            // We cannot use DateTimeImmutable::class because translation extractions fails on that
-            '\DateTimeImmutable',
-            sprintf(
-                'Last used on date must be formatted according to the ISO8601 standard, got "%s"',
-                $data['last_used_on']
             )
         );
 
@@ -104,7 +93,6 @@ final class ConsentListFactory
         return new Consent(
             self::createServiceProvider($data['service_provider']),
             $consentGivenOn,
-            $lastUsedOn,
             $consentType
         );
     }

--- a/src/OpenConext/Profile/Value/Consent.php
+++ b/src/OpenConext/Profile/Value/Consent.php
@@ -34,11 +34,6 @@ final class Consent
     private $consentGivenOn;
 
     /**
-     * @var DateTimeImmutable
-     */
-    private $lastUsedOn;
-
-    /**
      * @var ConsentType
      */
     private $consentType;
@@ -46,18 +41,15 @@ final class Consent
     /**
      * @param ServiceProvider $serviceProvider
      * @param DateTimeImmutable $consentGivenOn
-     * @param DateTimeImmutable $lastUsedOn
      * @param ConsentType $consentType
      */
     public function __construct(
         ServiceProvider $serviceProvider,
         DateTimeImmutable $consentGivenOn,
-        DateTimeImmutable $lastUsedOn,
         ConsentType $consentType
     ) {
         $this->serviceProvider = $serviceProvider;
         $this->consentGivenOn  = $consentGivenOn;
-        $this->lastUsedOn      = $lastUsedOn;
         $this->consentType     = $consentType;
     }
 
@@ -75,14 +67,6 @@ final class Consent
     public function getConsentGivenOn()
     {
         return $this->consentGivenOn;
-    }
-
-    /**
-     * @return DateTimeImmutable
-     */
-    public function getLastUsedOn()
-    {
-        return $this->lastUsedOn;
     }
 
     /**

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
@@ -52,9 +52,9 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td>{{ 'profile.my_services.consent_last_used_on'|trans }}:</td>
+                                <td>{{ 'profile.my_services.consent_first_used_on'|trans }}:</td>
                                 <td>
-                                    {{ specifiedConsent.consent.lastUsedOn.date|date('Y-m-d h:i')}}
+                                    {{ specifiedConsent.consent.consentGivenOn.date|date('Y-m-d h:i')}}
                                 </td>
                             </tr>
                         </table>

--- a/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
+++ b/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
@@ -104,7 +104,6 @@ class AttributeReleasePolicyServiceTest extends TestCase
                 new ContactEmailAddress('some@email.example')
             ),
             new DateTimeImmutable(),
-            new DateTimeImmutable(),
             ConsentType::explicit()
         );
         $anotherConsent = new Consent(
@@ -119,7 +118,6 @@ class AttributeReleasePolicyServiceTest extends TestCase
                 new Url('http://another-eula-url.example'),
                 new ContactEmailAddress('another@email.example')
             ),
-            new DateTimeImmutable(),
             new DateTimeImmutable(),
             ConsentType::explicit()
         );


### PR DESCRIPTION
[130002585](https://www.pivotaltracker.com/story/show/130002585)
OpenConext/OpenConext-engineblock#316
OpenConext/OpenConext-engineblock#367

This PR switches the last used consent date with the first used consent date as per the changes in the new Consent API, see linked issues and PRs.