### PR TITLE
Fix 'composer update'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.3",
-        "ibuildings/qa-tools": "2.0.x-dev",
+        "ibuildings/qa-tools": "2.x-dev",
         "liip/rmt": "^1.1",
         "matthiasnoback/symfony-config-test": "^1.3",
         "mockery/mockery": "^0.9.4"


### PR DESCRIPTION
It fails due to non-existing version:
https://packagist.org/packages/ibuildings/qa-tools#2.x-dev