### PR TITLE
Show sources of attributes in my services overview

### DIFF
--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -275,7 +275,12 @@ This profile page gives you insight in which personal data, provided by your ins
       <trans-unit id="41aded5ca8217152487f685b47f640799d76e24f" resname="profile.my_services.attribute_release_description">
         <source>profile.my_services.attribute_release_description</source>
         <target>This service receives the following information about you:</target>
-        <jms:reference-file line="65">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="1">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="069a217bbb82a2da6a0c01cb25256919a35b62af" resname="profile.my_services.attribute_release_description_with_source">
+        <source>profile.my_services.attribute_release_description_with_source</source>
+        <target>This service receives the following information about you from %source%:</target>
+        <jms:reference-file line="1">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
         <source>profile.my_services.consent_first_used_on</source>
@@ -456,7 +461,8 @@ This profile page gives you insight in which personal data, provided by your ins
         <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
         <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
         <jms:reference-file line="24">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="70">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="547ea301afc0bae2bdbdedec6915fa51c654ff52" resname="profile.table.attribute_value">
         <source>profile.table.attribute_value</source>
@@ -464,7 +470,22 @@ This profile page gives you insight in which personal data, provided by your ins
         <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
         <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
         <jms:reference-file line="25">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="0116d16056d9cd75bfe4bf170b5b504d8b939a38" resname="profile.table.source_description.orcid">
+        <source>profile.table.source_description.orcid</source>
+        <target>ORCID iD</target>
+        <jms:reference-file line="175">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="e591d4c6d94037cb4aca3294d989e63eeb15663f" resname="profile.table.source_description.sab">
+        <source>profile.table.source_description.sab</source>
+        <target>SURFnet Autorisatie Beheer</target>
+        <jms:reference-file line="176">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="4b1c5ddcfd432d3477264f068b21ff7996915e06" resname="profile.table.source_description.voot">
+        <source>profile.table.source_description.voot</source>
+        <target>Group membership</target>
+        <jms:reference-file line="174">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/messages.nl.xliff
+++ b/app/Resources/translations/messages.nl.xliff
@@ -275,7 +275,12 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
       <trans-unit id="41aded5ca8217152487f685b47f640799d76e24f" resname="profile.my_services.attribute_release_description">
         <source>profile.my_services.attribute_release_description</source>
         <target>Deze dienst ontvangt de volgende gegevens over jou:</target>
-        <jms:reference-file line="65">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="1">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="069a217bbb82a2da6a0c01cb25256919a35b62af" resname="profile.my_services.attribute_release_description_with_source">
+        <source>profile.my_services.attribute_release_description_with_source</source>
+        <target>Deze dienst ontvangt de volgende gegevens over jou van %source%:</target>
+        <jms:reference-file line="1">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
         <source>profile.my_services.consent_first_used_on</source>
@@ -456,7 +461,8 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
         <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
         <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
         <jms:reference-file line="24">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="70">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="547ea301afc0bae2bdbdedec6915fa51c654ff52" resname="profile.table.attribute_value">
         <source>profile.table.attribute_value</source>
@@ -464,7 +470,22 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
         <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
         <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
         <jms:reference-file line="25">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="0116d16056d9cd75bfe4bf170b5b504d8b939a38" resname="profile.table.source_description.orcid">
+        <source>profile.table.source_description.orcid</source>
+        <target>ORCID iD</target>
+        <jms:reference-file line="175">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="e591d4c6d94037cb4aca3294d989e63eeb15663f" resname="profile.table.source_description.sab">
+        <source>profile.table.source_description.sab</source>
+        <target>SURFnet Autorisatie Beheer</target>
+        <jms:reference-file line="176">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="4b1c5ddcfd432d3477264f068b21ff7996915e06" resname="profile.table.source_description.voot">
+        <source>profile.table.source_description.voot</source>
+        <target>Groepslidmaatschap</target>
+        <jms:reference-file line="174">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
@@ -81,7 +81,8 @@ final class AttributeReleasePolicyService
 
         $data = [
             'entityIds'  => $entityIds,
-            'attributes' => !empty($mappedAttributes) ? $mappedAttributes : new stdClass()
+            'attributes' => !empty($mappedAttributes) ? $mappedAttributes : new stdClass(),
+            'showSources' => true,
         ];
         $response = $this->jsonApiClient->post($data, '/arp');
 

--- a/src/OpenConext/Profile/Entity/AuthenticatedUser.php
+++ b/src/OpenConext/Profile/Entity/AuthenticatedUser.php
@@ -66,11 +66,6 @@ final class AuthenticatedUser
         foreach ($assertionAdapter->getAttributeSet() as $attribute) {
             $definition = $attribute->getAttributeDefinition();
 
-            // Filter out blacklisted attributes
-            if (in_array($definition->getUrnOid(), self::$blacklistedAttributes)) {
-                continue;
-            }
-
             // We only want to replace the eduPersonTargetedID attribute value as that is a nested NameID attribute
             if ($definition->getName() !== 'eduPersonTargetedID') {
                 $attributes[] = $attribute;

--- a/src/OpenConext/Profile/Tests/Value/SpecifiedConsentTest.php
+++ b/src/OpenConext/Profile/Tests/Value/SpecifiedConsentTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Copyright 2015 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\Profile\Tests\Value;
+
+use DateTimeImmutable;
+use OpenConext\Profile\Value\Consent;
+use OpenConext\Profile\Value\Consent\ServiceProvider;
+use OpenConext\Profile\Value\ConsentType;
+use OpenConext\Profile\Value\ContactEmailAddress;
+use OpenConext\Profile\Value\DisplayName;
+use OpenConext\Profile\Value\Entity;
+use OpenConext\Profile\Value\EntityId;
+use OpenConext\Profile\Value\EntityType;
+use OpenConext\Profile\Value\SpecifiedConsent;
+use OpenConext\Profile\Value\Url;
+use OpenConext\ProfileBundle\Attribute\AttributeSetWithFallbacks;
+use PHPUnit\Framework\TestCase;
+use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
+
+class SpecifiedConsentTest extends TestCase
+{
+    public function test_it_is_aware_of_multiple_attribute_sources()
+    {
+        $someAttributeDefinition = new AttributeDefinition(
+            'someAttribute',
+            'urn:mace:some-attribute',
+            'urn:oid:0.0.0.0.0.1'
+        );
+        $anotherAttributeDefinition = new AttributeDefinition('anotherAttribute', null, 'urn:oid:0.0.0.0.0.2');
+
+        $someConsent = new Consent(
+            new ServiceProvider(
+                new Entity(
+                    new EntityId('some-entity-id'),
+                    EntityType::SP()
+                ),
+                new DisplayName([
+                    'en' => 'Some display name'
+                ]),
+                new Url('http://some-eula-url.example'),
+                new ContactEmailAddress('some@email.example')
+            ),
+            new DateTimeImmutable(),
+            ConsentType::explicit()
+        );
+
+        // The results as expected to have been returned from the API (sources have been added)
+        $expectedSomeAttribute    = new Attribute($someAttributeDefinition, [['value' => 'some-value', 'source' => 'idp']]);
+        $expectedAnotherAttribute = new Attribute($anotherAttributeDefinition, [['value' => 'another-value', 'source' => 'voot']]);
+
+        $specifiedConsent = SpecifiedConsent::specifies(
+            $someConsent,
+            AttributeSetWithFallbacks::create([$expectedSomeAttribute, $expectedAnotherAttribute])
+        );
+
+        $this->assertTrue($specifiedConsent->hasMultipleSources());
+        $this->assertCount(2, $specifiedConsent->getReleasedAttributesGroupedBySource());
+    }
+
+    public function test_it_is_aware_of_a_single_attribute_sources()
+    {
+        $someAttributeDefinition = new AttributeDefinition(
+            'someAttribute',
+            'urn:mace:some-attribute',
+            'urn:oid:0.0.0.0.0.1'
+        );
+        $anotherAttributeDefinition = new AttributeDefinition('anotherAttribute', null, 'urn:oid:0.0.0.0.0.2');
+
+        $someConsent = new Consent(
+            new ServiceProvider(
+                new Entity(
+                    new EntityId('some-entity-id'),
+                    EntityType::SP()
+                ),
+                new DisplayName([
+                    'en' => 'Some display name'
+                ]),
+                new Url('http://some-eula-url.example'),
+                new ContactEmailAddress('some@email.example')
+            ),
+            new DateTimeImmutable(),
+            ConsentType::explicit()
+        );
+
+        // The results as expected to have been returned from the API (sources have been added)
+        $expectedSomeAttribute    = new Attribute($someAttributeDefinition, [['value' => 'some-value', 'source' => 'voot']]);
+        $expectedAnotherAttribute = new Attribute($anotherAttributeDefinition, [['value' => 'another-value', 'source' => 'voot']]);
+
+        $specifiedConsent = SpecifiedConsent::specifies(
+            $someConsent,
+            AttributeSetWithFallbacks::create([$expectedSomeAttribute, $expectedAnotherAttribute])
+        );
+
+        $this->assertFalse($specifiedConsent->hasMultipleSources());
+        $this->assertCount(1, $specifiedConsent->getReleasedAttributesGroupedBySource());
+    }
+    public function test_it_is_aware_of_zero_attribute_sources()
+    {
+        $someConsent = new Consent(
+            new ServiceProvider(
+                new Entity(
+                    new EntityId('some-entity-id'),
+                    EntityType::SP()
+                ),
+                new DisplayName([
+                    'en' => 'Some display name'
+                ]),
+                new Url('http://some-eula-url.example'),
+                new ContactEmailAddress('some@email.example')
+            ),
+            new DateTimeImmutable(),
+            ConsentType::explicit()
+        );
+
+        $specifiedConsent = SpecifiedConsent::specifies(
+            $someConsent,
+            AttributeSetWithFallbacks::create([])
+        );
+
+        $this->assertFalse($specifiedConsent->hasMultipleSources());
+        $this->assertEmpty($specifiedConsent->getReleasedAttributesGroupedBySource());
+    }
+}

--- a/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttribute.php
+++ b/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttribute.php
@@ -110,7 +110,7 @@ final class AttributeAggregationAttribute
         Assertion::keyExists($attributeData, 'source', 'The source should be set on the attribute');
         Assertion::string($attributeData['source'], 'The source should be a string');
 
-        $attribute = new self(
+        return new self(
             $attributeData['name'],
             '',
             '',
@@ -119,7 +119,6 @@ final class AttributeAggregationAttribute
             $attributeData['values'],
             $attributeData['source']
         );
-        return $attribute;
     }
 
     /**

--- a/src/OpenConext/Profile/Value/SpecifiedConsent.php
+++ b/src/OpenConext/Profile/Value/SpecifiedConsent.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\Profile\Value;
 
+use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
 
 class SpecifiedConsent
@@ -66,5 +67,32 @@ class SpecifiedConsent
     public function getReleasedAttributes()
     {
         return $this->releasedAttributes;
+    }
+
+    public function hasMultipleSources()
+    {
+        $sources = [];
+        foreach ($this->getReleasedAttributes() as $attribute) {
+            $source = $attribute->getValue()[0]['source'];
+            $sources[$source] = $source;
+        }
+
+        return count($sources) > 1;
+    }
+
+    /**
+     * Groups the released attributes on the group they originate from. This can be used to show the attributes.
+     *
+     * @return Attribute[]
+     */
+    public function getReleasedAttributesGroupedBySource()
+    {
+        $grouped = [];
+        foreach ($this->getReleasedAttributes() as $attribute) {
+            // The source is the same for all possible attribute values, so use the first one.
+            $source = $attribute->getValue()[0]['source'];
+            $grouped[$source][] = $attribute;
+        }
+        return $grouped;
     }
 }

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig
@@ -1,0 +1,29 @@
+<p class="aa-description">{{ 'profile.my_services.attribute_release_description_with_source'|trans({'%source%': ('profile.table.source_description.' ~ sourceName)|trans}) }}</p>
+
+<table class="mdl-data-table">
+    <thead>
+    <tr>
+        <th>{{ 'profile.table.attribute_name'|trans }}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for attribute in releasedAttributes %}
+        {% if attribute.attributeDefinition.hasUrnMace %}
+            {% set attributeUrn = attribute.attributeDefinition.urnMace %}
+        {% else %}
+            {% set attributeUrn = attribute.attributeDefinition.urnOid %}
+        {% endif %}
+        <tr>
+            <td title="{{ attributeUrn }}">
+                {% set translatedAttributeName = ('profile.saml.attributes.' ~ attribute.attributeDefinition.name)|trans({}, 'saml') %}
+
+                {% if translatedAttributeName == 'profile.saml.attributes.' ~ attribute.attributeDefinition.name %}
+                    <strong>{{ attributeUrn }}</strong>
+                {% else %}
+                    <strong>{{ translatedAttributeName }}</strong>
+                {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
@@ -1,0 +1,39 @@
+<p>{{ 'profile.my_services.attribute_release_description'|trans }}</p>
+
+<table class="mdl-data-table">
+    <thead>
+    <tr>
+        <th>{{ 'profile.table.attribute_name'|trans }}</th>
+        <th>{{ 'profile.table.attribute_value'|trans }}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for attribute in releasedAttributes %}
+        {% if attribute.attributeDefinition.hasUrnMace %}
+            {% set attributeUrn = attribute.attributeDefinition.urnMace %}
+        {% else %}
+            {% set attributeUrn = attribute.attributeDefinition.urnOid %}
+        {% endif %}
+        <tr>
+            <td title="{{ attributeUrn }}">
+                {% set translatedAttributeName = ('profile.saml.attributes.' ~ attribute.attributeDefinition.name)|trans({}, 'saml') %}
+
+                {% if translatedAttributeName == 'profile.saml.attributes.' ~ attribute.attributeDefinition.name %}
+                    <strong>{{ attributeUrn }}</strong>
+                {% else %}
+                    <strong>{{ translatedAttributeName }}</strong>
+                {% endif %}
+            </td>
+            <td>
+                {% for attributeValue in attribute.value  %}
+                    {% if attributeValue.value is iterable %}
+                        {{ attributeValue.value|join('\n')|nl2br }}
+                    {% else %}
+                        {{ attributeValue.value }}
+                    {% endif %}
+                {% endfor %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
@@ -11,7 +11,7 @@
         <li>{{ 'profile.my_services.explanation.explicit_consent'|trans }}</li>
         <li>{{ 'profile.my_services.explanation.implicit_consent'|trans }}</li>
     </ul>
-    {% if specifiedConsentList == null %}
+    {% if specifiedConsentList == null or specifiedConsentList is empty %}
     <p><i class="prepended fa fa-warning"></i>{{ 'profile.my_services.error_loading_consent'|trans }}</p>
     {% else %}
     <div class="table-overflow-container">

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
@@ -62,43 +62,13 @@
                             {% if specifiedConsent.releasedAttributes is empty %}
                             <p>{{ 'profile.my_services.no_attribute_released'|trans }}</p>
                             {% else %}
-                            <p>{{ 'profile.my_services.attribute_release_description'|trans }}</p>
-
-                            <table class="mdl-data-table">
-                                <thead>
-                                <tr>
-                                    <th>{{ 'profile.table.attribute_name'|trans }}</th>
-                                    <th>{{ 'profile.table.attribute_value'|trans }}</th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                {% for attribute in specifiedConsent.releasedAttributes %}
-                                    {% if attribute.attributeDefinition.hasUrnMace %}
-                                        {% set attributeUrn = attribute.attributeDefinition.urnMace %}
+                                {% for sourceName, releasedAttributes in specifiedConsent.releasedAttributesGroupedBySource  %}
+                                    {% if sourceName == 'idp' %}
+                                        {% include '@OpenConextProfile/MyServices/AttributeList/idp.html.twig' %}
                                     {% else %}
-                                        {% set attributeUrn = attribute.attributeDefinition.urnOid %}
+                                        {% include '@OpenConextProfile/MyServices/AttributeList/aa.html.twig' %}
                                     {% endif %}
-                                    <tr>
-                                        <td title="{{ attributeUrn }}">
-                                            {% set translatedAttributeName = ('profile.saml.attributes.' ~ attribute.attributeDefinition.name)|trans({}, 'saml') %}
-
-                                            {% if translatedAttributeName == 'profile.saml.attributes.' ~ attribute.attributeDefinition.name %}
-                                                <strong>{{ attributeUrn }}</strong>
-                                            {% else %}
-                                                <strong>{{ translatedAttributeName }}</strong>
-                                            {% endif %}
-                                        </td>
-                                        <td>
-                                            {% if attribute.value is iterable %}
-                                                {{ attribute.value|join('\n')|nl2br }}
-                                            {% else %}
-                                               {{ attribute.value }}
-                                            {% endif %}
-                                        </td>
-                                    </tr>
                                 {% endfor %}
-                                </tbody>
-                            </table>
                             {% endif %}
                         </div>
                     </div>

--- a/src/OpenConext/ProfileBundle/Resources/views/translations.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/translations.html.twig
@@ -170,3 +170,7 @@
 
 {{ 'profile.locale.locale_change_success'|trans }}
 {{ 'profile.locale.locale_change_fail'|trans }}
+
+{{ 'profile.table.source_description.voot'|trans }}
+{{ 'profile.table.source_description.orcid'|trans }}
+{{ 'profile.table.source_description.sab'|trans }}

--- a/src/OpenConext/ProfileBundle/Service/SpecifiedConsentListService.php
+++ b/src/OpenConext/ProfileBundle/Service/SpecifiedConsentListService.php
@@ -19,8 +19,8 @@
 namespace OpenConext\ProfileBundle\Service;
 
 use OpenConext\EngineBlockApiClientBundle\Service\AttributeReleasePolicyService;
-use OpenConext\Profile\Value\SpecifiedConsentList;
 use OpenConext\Profile\Entity\AuthenticatedUser;
+use OpenConext\Profile\Value\SpecifiedConsentList;
 
 class SpecifiedConsentListService
 {
@@ -53,6 +53,13 @@ class SpecifiedConsentListService
     public function getListFor(AuthenticatedUser $user)
     {
         $consentList = $this->consentService->findAllFor($user);
+
+        // There is an off chance the user didn't give consent yet, in that case the consent list is null. It's not
+        // possible to apply ARP on empty consent list.
+        if (is_null($consentList)) {
+            // So return an empty SpecifiedConsentList
+            return SpecifiedConsentList::createWith([]);
+        }
 
         return $this->attributeReleasePolicyService->applyAttributeReleasePolicies(
             $consentList,

--- a/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
+++ b/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
@@ -76,18 +76,39 @@ class AttributeReleasePolicyServiceTest extends TestCase
                             'urn:oid:0.0.0.0.0.1' => ['some-value'],
                             'urn:oid:0.0.0.0.0.2' => ['another-value'],
                         ],
+                        'showSources' => true
                     ],
                     '/arp',
                 ]
             )
             ->andReturn([
                 'some-entity-id' => [
-                    'urn:mace:some-attribute' => ['some-value'],
-                    'urn:oid:0.0.0.0.0.1' => ['some-value'],
-                    'urn:oid:0.0.0.0.0.2' => ['another-value']
+                    'urn:mace:some-attribute' => [
+                        [
+                            'value' => 'some-value',
+                            'source' => 'idp',
+                        ],
+                    ],
+                    'urn:oid:0.0.0.0.0.1' => [
+                        [
+                            'value' => 'some-value',
+                            'source' => 'idp',
+                        ],
+                    ],
+                    'urn:oid:0.0.0.0.0.2' => [
+                        [
+                            'value' => 'another-value',
+                            'source' => 'idp',
+                        ],
+                    ],
                 ],
                 'another-entity-id' => [
-                    'urn:oid:0.0.0.0.0.2' => ['another-value']
+                    'urn:oid:0.0.0.0.0.2' => [
+                        [
+                            'value' => 'another-value',
+                            'source' => 'idp',
+                        ],
+                    ]
                 ],
             ]);
 
@@ -125,14 +146,18 @@ class AttributeReleasePolicyServiceTest extends TestCase
 
         $someAttribute    = new Attribute($someAttributeDefinition, ['some-value']);
         $anotherAttribute = new Attribute($anotherAttributeDefinition, ['another-value']);
+
+        // The results as expected to have been returned from the API (sources have been added)
+        $expectedSomeAttribute    = new Attribute($someAttributeDefinition, [['value' => 'some-value', 'source' => 'idp']]);
+        $expectedAnotherAttribute = new Attribute($anotherAttributeDefinition, [['value' => 'another-value', 'source' => 'idp']]);
         $attributeSet     = AttributeSet::create([$someAttribute, $anotherAttribute,]);
 
         $expectedResult = SpecifiedConsentList::createWith([
             SpecifiedConsent::specifies(
                 $someConsent,
-                AttributeSetWithFallbacks::create([$someAttribute, $anotherAttribute])
+                AttributeSetWithFallbacks::create([$expectedSomeAttribute, $expectedAnotherAttribute])
             ),
-            SpecifiedConsent::specifies($anotherConsent, AttributeSetWithFallbacks::create([$anotherAttribute]))
+            SpecifiedConsent::specifies($anotherConsent, AttributeSetWithFallbacks::create([$expectedAnotherAttribute]))
         ]);
 
         $result = $arpService->applyAttributeReleasePolicies($consentList, $attributeSet);

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -169,9 +169,16 @@ i.prepended {
     text-align: left;
     padding: 16px 12px;
 }
+.mdl-layout__content .content-container .overview-table th:first-child {
+    min-width: 200px;
+}
 .mdl-layout__content .content-container .overview-table th {
     font-weight: 300;
     color: #a2a2a2;
+}
+
+.mdl-layout__content .content-container .overview-table p.aa-description {
+    margin: 1em 0;
 }
 
 .mdl-layout__content .content-container img {


### PR DESCRIPTION
Sources are retrieved from Engineblock Api. The changes are built on top of the changes made in `feature/account-linking-information`. 

**Test instructions**
I've updated one of the services in service registry to apply the arp. And then configured some attribute sources to originate from voot/sab.

Also see this [EB PR](https://github.com/OpenConext/OpenConext-engineblock/pull/457)