### PR TITLE
Separate multi valued attributes with newline

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig
@@ -44,7 +44,7 @@
                     </td>
                     <td>
                         {% if attribute.value is iterable %}
-                            {{ attribute.value|join(', ') }}
+                            {{ attribute.value|join('\n')|nl2br }}
                         {% else %}
                             {{ attribute.value }}
                         {% endif %}

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
@@ -90,7 +90,7 @@
                                         </td>
                                         <td>
                                             {% if attribute.value is iterable %}
-                                                {{ attribute.value|join(', ') }}
+                                                {{ attribute.value|join('\n')|nl2br }}
                                             {% else %}
                                                {{ attribute.value }}
                                             {% endif %}


### PR DESCRIPTION
To get a multi value attribute hack the following into `\OpenConext\Profile\Entity\AuthenticatedUser::createFrom` on line 67:

`$attributes[] = new Attribute($definition, [$eptiValues[0]['Value'], 'Foobar', 'Lorem ipsum']);`

The story only spoke about changing the my profile page. I've taken the liberty to apply the same logic to the my services attribute lists.