### PR TITLE
Filter blacklisted attributes

### DIFF
--- a/src/OpenConext/Profile/Entity/AuthenticatedUser.php
+++ b/src/OpenConext/Profile/Entity/AuthenticatedUser.php
@@ -43,6 +43,15 @@ final class AuthenticatedUser
     private $authenticatingAuthorities;
 
     /**
+     * A list of blacklisted attributes defined by their Urn OID
+     * @var array
+     */
+    private static $blacklistedAttributes = [
+        'urn:oid:1.3.6.1.4.1.1076.20.40.40.1',
+        'urn:oid:1.3.6.1.4.1.1466.115.121.1.15',
+    ];
+
+    /**
      * @param AssertionAdapter $assertionAdapter
      * @param EntityId[] $authenticatingAuthorities
      *
@@ -56,6 +65,11 @@ final class AuthenticatedUser
         /** @var Attribute $attribute */
         foreach ($assertionAdapter->getAttributeSet() as $attribute) {
             $definition = $attribute->getAttributeDefinition();
+
+            // Filter out blacklisted attributes
+            if (in_array($definition->getUrnOid(), self::$blacklistedAttributes)) {
+                continue;
+            }
 
             // We only want to replace the eduPersonTargetedID attribute value as that is a nested NameID attribute
             if ($definition->getName() !== 'eduPersonTargetedID') {

--- a/src/OpenConext/Profile/Tests/Entity/AuthenticatedUserTest.php
+++ b/src/OpenConext/Profile/Tests/Entity/AuthenticatedUserTest.php
@@ -90,6 +90,52 @@ class AuthenticatedUserTest extends TestCase
      * @test
      * @group Authentication
      * @group Attributes
+     */
+    public function attributes_are_filtered_when_creating_an_authenticated_user()
+    {
+        $expectedAttributeSet = AttributeSet::create([
+            new Attribute(
+                new AttributeDefinition('displayName', 'urn:mace:dir:attribute-def:displayName'),
+                ['Chuck', 'Tester']
+            ),
+            new Attribute(
+                new AttributeDefinition('commonName', 'urn:mace:dir:attribute-def:cn'),
+                ['Chuck Tester']
+            )
+        ]);
+
+        $attributeSet = AttributeSet::create([
+            new Attribute(
+                new AttributeDefinition('displayName', 'urn:mace:dir:attribute-def:displayName'),
+                ['Chuck', 'Tester']
+            ),
+            new Attribute(
+                new AttributeDefinition('commonName', 'urn:mace:dir:attribute-def:cn'),
+                ['Chuck Tester']
+            ),
+            new Attribute(
+                new AttributeDefinition('Organization', '', 'urn:oid:1.3.6.1.4.1.1076.20.40.40.1'),
+                ['My Organization']
+            ),
+            new Attribute(
+                new AttributeDefinition('LDAP Directory string', '', 'urn:oid:1.3.6.1.4.1.1466.115.121.1.15'),
+                ['testers/chuck1']
+            )
+        ]);
+
+        $assertionAdapter = $this->mockAssertionAdapterWith($attributeSet, 'test NameID');
+
+        $authenticatedUser  = AuthenticatedUser::createFrom($assertionAdapter, []);
+        $actualAttributeSet = $authenticatedUser->getAttributes();
+
+        $this->assertCount(2, $actualAttributeSet);
+        $this->assertEquals($expectedAttributeSet, $actualAttributeSet);
+    }
+
+    /**
+     * @test
+     * @group Authentication
+     * @group Attributes
      *
      */
     public function epti_attribute_cannot_be_set_if_its_value_has_multiple_name_ids_when_creating_an_authenticated_user()


### PR DESCRIPTION
The urn:oid:1.3.6.1.4.1.1076.20.40.40.1 and urn:oid:1.3.6.1.4.1.1466.115.121.1.15 attributes are not to be shown to end users. These attributes are only kept for historic reasons. So filter them when evaluating their attributes.

A test was added to ascertain the attribute filtering actually works.

**Test instructions**
When logging in with a mujina student before you will see two Organization attributes in the my profile attribute listing.

After applying the changes of this PR, one of them is no longer present.