### PR TITLE
Filter blacklisted attributes

### DIFF
--- a/src/OpenConext/Profile/Entity/AuthenticatedUser.php
+++ b/src/OpenConext/Profile/Entity/AuthenticatedUser.php
@@ -134,4 +134,22 @@ final class AuthenticatedUser
     {
         return $this->nameId;
     }
+
+    /**
+     * @return AttributeSet
+     */
+    public function getAttributesFiltered()
+    {
+        $attributes = $this->getAttributes();
+        $filtered = [];
+        /** @var Attribute $attribute */
+        foreach ($attributes as $attribute) {
+            // Filter out blacklisted attributes
+            if (in_array($attribute->getAttributeDefinition()->getUrnOid(), self::$blacklistedAttributes)) {
+                continue;
+            }
+            $filtered[] = $attribute;
+        }
+        return AttributeSet::create($filtered);
+    }
 }

--- a/src/OpenConext/Profile/Entity/User.php
+++ b/src/OpenConext/Profile/Entity/User.php
@@ -83,7 +83,7 @@ final class User implements UserInterface
 
     public function getAttributes()
     {
-        return $this->authenticatedUser->getAttributes();
+        return $this->authenticatedUser->getAttributesFiltered();
     }
 
     public function getId()

--- a/src/OpenConext/Profile/Tests/Entity/AuthenticatedUserTest.php
+++ b/src/OpenConext/Profile/Tests/Entity/AuthenticatedUserTest.php
@@ -114,7 +114,7 @@ class AuthenticatedUserTest extends TestCase
                 ['Chuck Tester']
             ),
             new Attribute(
-                new AttributeDefinition('Organization', '', 'urn:oid:1.3.6.1.4.1.1076.20.40.40.1'),
+                new AttributeDefinition('Organization', 'urn:mace:surfconextid', 'urn:oid:1.3.6.1.4.1.1076.20.40.40.1'),
                 ['My Organization']
             ),
             new Attribute(
@@ -126,7 +126,7 @@ class AuthenticatedUserTest extends TestCase
         $assertionAdapter = $this->mockAssertionAdapterWith($attributeSet, 'test NameID');
 
         $authenticatedUser  = AuthenticatedUser::createFrom($assertionAdapter, []);
-        $actualAttributeSet = $authenticatedUser->getAttributes();
+        $actualAttributeSet = $authenticatedUser->getAttributesFiltered();
 
         $this->assertCount(2, $actualAttributeSet);
         $this->assertEquals($expectedAttributeSet, $actualAttributeSet);

--- a/src/OpenConext/ProfileBundle/Service/SpecifiedConsentListService.php
+++ b/src/OpenConext/ProfileBundle/Service/SpecifiedConsentListService.php
@@ -56,7 +56,7 @@ class SpecifiedConsentListService
 
         return $this->attributeReleasePolicyService->applyAttributeReleasePolicies(
             $consentList,
-            $user->getAttributes()
+            $user->getAttributesFiltered()
         );
     }
 }


### PR DESCRIPTION
This is a fix of the previously merged PR: #84 

Filtering the attributes from the user at earliest possible occasion was not the way to go. The SamlProvider creates an AuthenticateUser instance when the user logs in. This authenticated user is loaded with the saml attributes from the assertion of the SAML response.

Filtering the attributes at that point proved to be problematic for other parts of the application as they relied on the `urn:oid:1.3.6.1.4.1.1076.20.40.40.1` (surfconextid) to be present in the list of user attributes.

To solve this problem, a new getAttributes method was introduced on the AuthenticateUser class. Who is tasked with filtering the blacklisted attributes on a 'just in time' basis, leaving the required attributes in place for other processes to use.