### PR TITLE
Install Monitor bundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -36,6 +36,7 @@ class AppKernel extends Kernel
             new Nelmio\SecurityBundle\NelmioSecurityBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Surfnet\SamlBundle\SurfnetSamlBundle(),
+            new OpenConext\MonitorBundle\OpenConextMonitorBundle(),
 
             // Project
             new OpenConext\ProfileBundle\OpenConextProfileBundle(),

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -2,6 +2,10 @@ open_conext_profile:
     resource:   "@OpenConextProfileBundle/Resources/config/routing.yml"
     prefix:     /
 
+openconext_monitor:
+    resource:   "@OpenConextMonitorBundle/Resources/config/routing.yml"
+    prefix:     /
+
 nelmio_security_report:
     path:       /csp/report
     methods:    [POST]

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -12,6 +12,10 @@ security:
             pattern: ^/authentication/metadata$
             anonymous: ~
 
+        monitor:
+            pattern: ^/(info|health)$
+            security: false
+
         saml_based:
             saml: true
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "beberlei/assert": "^2.4",
         "guzzlehttp/guzzle": "^6.1",
         "nelmio/security-bundle": "^1.8",
-        "symfony/swiftmailer-bundle": "^2.4"
+        "symfony/swiftmailer-bundle": "^2.4",
+        "openconext/monitor-bundle": "^1.0"
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d41582bb543d7326a6d943091f7273a",
+    "content-hash": "d7943fa240a78997d0d95118e72898cd",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1206,6 +1206,59 @@
             "time": "2016-09-16T12:04:44+00:00"
         },
         {
+            "name": "openconext/monitor-bundle",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OpenConext/Monitor-bundle.git",
+                "reference": "b9be093828385e857ff23a106b4429155d7f8d58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OpenConext/Monitor-bundle/zipball/b9be093828385e857ff23a106b4429155d7f8d58",
+                "reference": "b9be093828385e857ff23a106b4429155d7f8d58",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4,<8.0-dev",
+                "symfony/dependency-injection": ">=2.7,<4",
+                "symfony/framework-bundle": ">=2.7,<4",
+                "webmozart/assert": "^1.2"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "liip/rmt": "^1.1",
+                "malukenho/docheader": "^0.1.6",
+                "matthiasnoback/symfony-config-test": "^2.1",
+                "mockery/mockery": "~0.9",
+                "phpdocumentor/reflection-docblock": "3.3.*",
+                "phpmd/phpmd": "^2.6",
+                "phpunit/php-token-stream": "1.4.*",
+                "phpunit/phpunit": "^5.7",
+                "sebastian/phpcpd": "^3.0",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "OpenConext\\MonitorBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "A Symfony2 bundle that facilitates health and info endpoints to a Symfony application",
+            "keywords": [
+                "OpenConext",
+                "health",
+                "monitoring",
+                "stepup",
+                "surfnet"
+            ],
+            "time": "2017-12-07T14:41:46+00:00"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v1.4.1",
             "source": {
@@ -2189,6 +2242,56 @@
                 "templating"
             ],
             "time": "2017-09-27T18:06:46+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "packages-dev": [
@@ -2399,12 +2502,12 @@
             "version": "v2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/matthiasnoback/SymfonyConfigTest.git",
+                "url": "https://github.com/SymfonyTest/SymfonyConfigTest.git",
                 "reference": "dbf93be91b8004203029301bf98142bd06de4f5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matthiasnoback/SymfonyConfigTest/zipball/dbf93be91b8004203029301bf98142bd06de4f5a",
+                "url": "https://api.github.com/repos/SymfonyTest/SymfonyConfigTest/zipball/dbf93be91b8004203029301bf98142bd06de4f5a",
                 "reference": "dbf93be91b8004203029301bf98142bd06de4f5a",
                 "shasum": ""
             },
@@ -4049,56 +4152,6 @@
                 "versioning"
             ],
             "time": "2015-05-02T19:28:54+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/src/OpenConext/EngineBlockApiClientBundle/HealthCheck/ApiHealthCheck.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/HealthCheck/ApiHealthCheck.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\EngineBlockApiClientBundle\HealthCheck;
+
+use Exception;
+use OpenConext\MonitorBundle\HealthCheck\HealthCheckInterface;
+use OpenConext\MonitorBundle\HealthCheck\HealthReportInterface;
+use OpenConext\MonitorBundle\Value\HealthReport;
+use OpenConext\Profile\Repository\ConsentRepository;
+
+class ApiHealthCheck implements HealthCheckInterface
+{
+    /**
+     * @var ConsentRepository
+     */
+    private $repository;
+
+    public function __construct(ConsentRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param HealthReportInterface $report
+     * @return HealthReportInterface
+     */
+    public function check(HealthReportInterface $report)
+    {
+        try {
+            $this->repository->findAllFor('a73b204b8d896a55b34e41e71f0138f81e81f4da');
+        } catch (Exception $e) {
+            return HealthReport::buildStatusDown(
+                sprintf(
+                    'EngineBlock API is not responding as expected. Message "%s" of type "%s".',
+                    $e->getMessage(),
+                    get_class($e)
+                )
+            );
+        }
+        return $report;
+    }
+}

--- a/src/OpenConext/EngineBlockApiClientBundle/Resources/config/services.yml
+++ b/src/OpenConext/EngineBlockApiClientBundle/Resources/config/services.yml
@@ -29,3 +29,10 @@ services:
         arguments:
             - @openconext_eb_api.service.api
             - @surfnet_saml.saml.attribute_dictionary
+
+    openconext_eb_api.monitor.api_health_check:
+        class: OpenConext\EngineBlockApiClientBundle\HealthCheck\ApiHealthCheck
+        arguments:
+            - @openconext_eb_api.repository.consent
+        tags:
+            - { name: surfnet.monitor.health_check }


### PR DESCRIPTION
The health and info responses can be requested at respectively: hostname/health and hostname/info

The endpoints are not restricted by firewall rules and thus are publically available. This should be restricted by the load balancer.

The bundle is extended with an extra health checker for the engine block API. For now, a consent request is performed for a nonexistent user. This is less than elegant and preferably the engine endpoints receive a health endpoint themselves.