### PR TITLE
Support account list in attribute aggregator response

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -137,10 +137,10 @@ open_conext_profile:
         email_to: %information_request_email_to%
     # An array of attribute identifiers supported by attribute aggregation
     attribute_aggregation_supported_attributes:
-        # The identifier of the attribute. Should match the value of the name attribute from the Attribute Aggregation
-        # API response. For a list of supported attributes see:
+        # The accountType of the attribute. Should match the value of the name attribute from the Attribute Aggregation
+        # API account list response. For a list of supported attributes see:
         # https://wiki.surfnet.nl/display/surfconextdev/Attributen+in+SURFconext
-        'urn:mace:dir:attribute-def:eduPersonOrcid':
+        'ORCID':
             # The relative path to an image. Starting from the /web folder
             logo_path: %attribute_aggregation_orcid_logo_path%
             # The Url where the attribute can be connected

--- a/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttribute.php
+++ b/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttribute.php
@@ -25,17 +25,12 @@ final class AttributeAggregationAttribute
     /**
      * @var string
      */
-    private $identifier;
+    private $accountType;
 
     /**
      * @var string
      */
-    private $values;
-
-    /**
-     * @var string
-     */
-    private $source;
+    private $linkedId;
 
     /**
      * @var string
@@ -58,75 +53,76 @@ final class AttributeAggregationAttribute
     private $isConnected = false;
 
     /**
-     * @param string $identifier
+     * @param string $accountType
+     * @param string $linkedId
      * @param string $logoPath
      * @param string $connectUrl
      * @param string $disconnectUrl
      * @param bool $isConnected
-     * @param array $values
-     * @param $source
      */
     public function __construct(
-        $identifier,
+        $accountType,
+        $linkedId,
         $logoPath,
         $connectUrl,
         $disconnectUrl,
-        $isConnected,
-        array $values = null,
-        $source = null
+        $isConnected
     ) {
-        $this->identifier = $identifier;
+        $this->accountType = $accountType;
+        $this->linkedId = $linkedId;
         $this->logoPath = $logoPath;
         $this->connectUrl = $connectUrl;
         $this->disconnectUrl = $disconnectUrl;
         $this->isConnected = $isConnected;
-        $this->values = $values;
-        $this->source = $source;
     }
 
     public static function fromConfig(
         AttributeAggregationAttributeConfiguration $enabledAttribute,
         $isConnected,
-        array $values = null,
-        $source = null
+        $linkedId = null
     ) {
         return new self(
-            $enabledAttribute->getIdentifier(),
+            $enabledAttribute->getAccountType(),
+            $linkedId,
             $enabledAttribute->getLogoPath(),
             $enabledAttribute->getConnectUrl(),
             $enabledAttribute->getDisconnectUrl(),
-            $isConnected,
-            $values,
-            $source
+            $isConnected
         );
     }
 
     public static function fromApiResponse(array $attributeData)
     {
-        Assertion::keyExists($attributeData, 'name', 'The name should be set on the attribute');
-        Assertion::string($attributeData['name'], 'The name should be a string');
-        Assertion::keyExists($attributeData, 'values', 'The values should be set on the attribute');
-        Assertion::isArray($attributeData['values'], 'The values should be an array');
-        Assertion::keyExists($attributeData, 'source', 'The source should be set on the attribute');
-        Assertion::string($attributeData['source'], 'The source should be a string');
+        Assertion::keyExists($attributeData, 'accountType', 'No account type found on attribute');
+        Assertion::string($attributeData['accountType'], 'Account type should be a string');
+
+        Assertion::keyExists($attributeData, 'linkedId', 'No linked id found on attribute');
+        Assertion::string($attributeData['linkedId'], 'Linked id should be a string');
 
         return new self(
-            $attributeData['name'],
+            $attributeData['accountType'],
+            $attributeData['linkedId'],
             '',
             '',
             '',
-            true,
-            $attributeData['values'],
-            $attributeData['source']
+            true
         );
     }
 
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getAccountType()
     {
-        return $this->identifier;
+        return $this->accountType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLinkedId()
+    {
+        return $this->linkedId;
     }
 
     /**
@@ -159,21 +155,5 @@ final class AttributeAggregationAttribute
     public function isConnected()
     {
         return $this->isConnected;
-    }
-
-    /**
-     * @return string
-     */
-    public function getValues()
-    {
-        return $this->values;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSource()
-    {
-        return $this->source;
     }
 }

--- a/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttributeConfiguration.php
+++ b/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttributeConfiguration.php
@@ -23,7 +23,7 @@ final class AttributeAggregationAttributeConfiguration
     /**
      * @var string
      */
-    private $identifier;
+    private $accountType;
 
     /**
      * @var string
@@ -41,23 +41,23 @@ final class AttributeAggregationAttributeConfiguration
     private $disconnectUrl;
 
     /**
-     * @param string $identifier
+     * @param string $accountType
      * @param string $logoPath
      * @param string $connectUrl
      * @param string $disconnectUrl
      */
-    public function __construct($identifier, $logoPath, $connectUrl, $disconnectUrl)
+    public function __construct($accountType, $logoPath, $connectUrl, $disconnectUrl)
     {
-        $this->identifier = $identifier;
+        $this->accountType = $accountType;
         $this->logoPath = $logoPath;
         $this->connectUrl = $connectUrl;
         $this->disconnectUrl = $disconnectUrl;
     }
 
-    public static function fromConfig($identifier, $attributeConfigParameters)
+    public static function fromConfig($accountType, $attributeConfigParameters)
     {
         return new self(
-            $identifier,
+            $accountType,
             $attributeConfigParameters['logo_path'],
             $attributeConfigParameters['connect_url'],
             $attributeConfigParameters['disconnect_url']
@@ -67,9 +67,9 @@ final class AttributeAggregationAttributeConfiguration
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getAccountType()
     {
-        return $this->identifier;
+        return $this->accountType;
     }
 
     /**

--- a/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttributesList.php
+++ b/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttributesList.php
@@ -60,13 +60,13 @@ final class AttributeAggregationAttributesList
     }
 
     /**
-     * @param $identifier
+     * @param string $accountType
      * @return bool
      */
-    public function hasAttribute($identifier)
+    public function hasAttribute($accountType)
     {
         foreach ($this->attributes as $attribute) {
-            if ($attribute->getIdentifier() === $identifier) {
+            if ($attribute->getAccountType() === $accountType) {
                 return true;
             }
         }
@@ -78,28 +78,28 @@ final class AttributeAggregationAttributesList
         $this->attributes = array_filter(
             $this->attributes,
             function (AttributeAggregationAttribute $attribute) use ($enabledAttributes) {
-                return $enabledAttributes->isEnabled($attribute->getIdentifier());
+                return $enabledAttributes->isEnabled($attribute->getAccountType());
             }
         );
     }
 
     /**
-     * @param $identifier
+     * @param string $accountType
      * @return AttributeAggregationAttribute
      * @throws InvalidArgumentException
      */
-    public function getAttribute($identifier)
+    public function getAttribute($accountType)
     {
         foreach ($this->attributes as $attribute) {
-            if ($attribute->getIdentifier() === $identifier) {
+            if ($attribute->getAccountType() === $accountType) {
                 return $attribute;
             }
         }
 
         throw new InvalidArgumentException(
             sprintf(
-                'The requested attribute with identifier "%s" could not be found',
-                $identifier
+                'The requested attribute for account type "%s" could not be found',
+                $accountType
             )
         );
     }

--- a/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationEnabledAttributes.php
+++ b/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationEnabledAttributes.php
@@ -30,9 +30,9 @@ final class AttributeAggregationEnabledAttributes
      */
     public function __construct(array $attributes)
     {
-        foreach ($attributes as $attributeIdentifier => $attribute) {
-            $this->attributes[$attributeIdentifier] = AttributeAggregationAttributeConfiguration::fromConfig(
-                $attributeIdentifier,
+        foreach ($attributes as $accountType => $attribute) {
+            $this->attributes[$accountType] = AttributeAggregationAttributeConfiguration::fromConfig(
+                $accountType,
                 $attribute
             );
         }
@@ -46,8 +46,8 @@ final class AttributeAggregationEnabledAttributes
         return $this->attributes;
     }
 
-    public function isEnabled($identifier)
+    public function isEnabled($accountType)
     {
-        return array_key_exists($identifier, $this->attributes);
+        return array_key_exists($accountType, $this->attributes);
     }
 }

--- a/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
@@ -27,7 +27,7 @@
                     </div>
                     <div class="mdl-cell mdl-cell--3-col">
                         <div class="mdl-layout-title">{{ 'profile.my_connections.orcid.title'|trans }}</div>
-                        <p>{{ orcid.values[0] }}</p>
+                        <p>{{ orcid.linkedId }}</p>
                     </div>
                     <div class="mdl-cell mdl-cell--3-col">
                         <div class="mdl-layout-title">{{ 'profile.my_connections.orcid.status'|trans }}</div>

--- a/src/OpenConext/ProfileBundle/Service/AttributeAggregationService.php
+++ b/src/OpenConext/ProfileBundle/Service/AttributeAggregationService.php
@@ -83,14 +83,13 @@ final class AttributeAggregationService
                 $attributeAggregationAttributes = $this->repository->findAllFor($surfConextId);
 
                 foreach ($enabledAttributes->getAttributes() as $enabledAttribute) {
-                    $identifier = $enabledAttribute->getIdentifier();
-                    if ($attributeAggregationAttributes->hasAttribute($identifier)) {
-                        $aaAttribute = $attributeAggregationAttributes->getAttribute($identifier);
+                    $accountType = $enabledAttribute->getAccountType();
+                    if ($attributeAggregationAttributes->hasAttribute($accountType)) {
+                        $aaAttribute = $attributeAggregationAttributes->getAttribute($accountType);
                         $collection[] = AttributeAggregationAttribute::fromConfig(
                             $enabledAttribute,
                             true,
-                            $aaAttribute->getValues(),
-                            $aaAttribute->getSource()
+                            $aaAttribute->getLinkedId()
                         );
                     } else {
                         $collection[] = AttributeAggregationAttribute::fromConfig($enabledAttribute, false);


### PR DESCRIPTION
Asking the attribute aggregator for a list of connected accounts
returns a response like:

    [
       {
          "accountType" : "ORCID",
          "created" : 1509708987,
          "id" : 50,
          "linkedId" : "http://orcid.org/0000-0002-5385-9420",
          "schacHome" : "surfnet.nl",
          "urn" : "urn:collab:person:surfnet.nl:kinkhorst"
       }
    ]

Previous implementation expected an ARP reply, which is not how
profile obtains the connection status of linked accounts. Major
difference is that we now configure the accountType (ORCID) instead of
the urn of the attribute and match that to the account list.