### PR TITLE
Show attribute values in paragraphs

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
@@ -26,11 +26,7 @@
             </td>
             <td>
                 {% for attributeValue in attribute.value  %}
-                    {% if attributeValue.value is iterable %}
-                        {{ attributeValue.value|join('\n')|nl2br }}
-                    {% else %}
-                        {{ attributeValue.value }}
-                    {% endif %}
+                    <p class="attribute-value">{{ attributeValue.value }}</p>
                 {% endfor %}
             </td>
         </tr>

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -169,6 +169,9 @@ i.prepended {
     text-align: left;
     padding: 16px 12px;
 }
+.mdl-layout__content .content-container .overview-table td table p.attribute-value {
+    margin: 0;
+}
 .mdl-layout__content .content-container .overview-table th:first-child {
     min-width: 200px;
 }


### PR DESCRIPTION
**Review notes**
The attribute values were retrieved using the getValue method on the
Attribute class (SAML2 Assertion). This returned the attributes in an
aggregated manner. When iterating the attribute values, all values
are displayed in a paragraph without margin. Ensuring attributes with
multiple values are displayed beneath each other.

**Test note**
To test with attributes with multiple values do the following:

Open: `src/OpenConext/ProfileBundle/Attribute/AttributeSetWithFallbacks.php`

Just above line 43, you can add `attributeValues` to the existing values array. This could look like this: 

```php
    public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
    {
        $attributeSet = new AttributeSetWithFallbacks();

        foreach ($assertion->getAttributes() as $urn => $attributeValue) {
            try {
                $attributeDefinition = $attributeDictionary->getAttributeDefinitionByUrn($urn);
            } catch (UnknownUrnException $exception) {
                $attributeDefinition = new AttributeDefinition($urn, $urn, $urn);
            }
            $attributeValue[] = 'added value';
            $attributeSet->initializeWith(new Attribute($attributeDefinition, $attributeValue));
        }

        return $attributeSet;
    }
```

Note that the AttributeSetWithFallbacks is created at authentication time. So changes will only be noticable after re-authentication.