### PR TITLE
Show attributes from AA sources in My Services

### DIFF
--- a/app/Resources/translations/saml.en.xliff
+++ b/app/Resources/translations/saml.en.xliff
@@ -836,6 +836,11 @@
         <target state="new">profile.saml.attributes.x500UniqueIdentifier</target>
         <jms:reference-file line="166">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="4515e8389ffe28d89df023a830d6f579fd43a6c1" resname="profile.saml.attributes.eduPersonOrcid">
+        <source>profile.saml.attributes.eduPersonOrcid</source>
+        <target state="new">ORCiD ID</target>
+        <jms:reference-file line="166">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/composer.lock
+++ b/composer.lock
@@ -1661,16 +1661,16 @@
         },
         {
             "name": "surfnet/stepup-saml-bundle",
-            "version": "2.6.3",
+            "version": "2.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OpenConext/Stepup-saml-bundle.git",
-                "reference": "2c1e4c084d790f49e867a4c33463b2da872a4182"
+                "reference": "dbc2685f1aac66697d2c867d529608ff036cb28b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/2c1e4c084d790f49e867a4c33463b2da872a4182",
-                "reference": "2c1e4c084d790f49e867a4c33463b2da872a4182",
+                "url": "https://api.github.com/repos/OpenConext/Stepup-saml-bundle/zipball/dbc2685f1aac66697d2c867d529608ff036cb28b",
+                "reference": "dbc2685f1aac66697d2c867d529608ff036cb28b",
                 "shasum": ""
             },
             "require": {
@@ -1678,8 +1678,8 @@
                 "php": ">=5.4,<8.0-dev",
                 "robrichards/xmlseclibs": "^1.4.0",
                 "simplesamlphp/saml2": "^1.8",
-                "symfony/dependency-injection": "^2.7",
-                "symfony/framework-bundle": "^2.7"
+                "symfony/dependency-injection": ">=2.7,<4",
+                "symfony/framework-bundle": ">=2.7,<4"
             },
             "require-dev": {
                 "ibuildings/qa-tools": "~1.1",
@@ -1705,7 +1705,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2016-12-12T12:31:10+00:00"
+            "time": "2018-01-09T14:13:18+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
@@ -89,11 +89,8 @@ final class AttributeReleasePolicyService
         // Arp is applied for all entities
         $response = $this->jsonApiClient->post($data, '/arp');
 
-        $data = [
-            'entityIds'  => $entityIds,
-        ];
         // Arp information is retrieved for all entities with arp enabled.
-        $arpResponse = $this->jsonApiClient->post($data, '/read-arp');
+        $arpResponse = $this->jsonApiClient->read('/read-arp?entityIds=%s', [implode(',', $entityIds)]);
 
         $specifiedConsents = $consentList->map(
             function (Consent $consent) use ($response, $arpResponse) {

--- a/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
@@ -20,6 +20,7 @@ namespace OpenConext\EngineBlockApiClientBundle\Service;
 
 use OpenConext\EngineBlockApiClientBundle\Exception\InvalidResponseException;
 use OpenConext\EngineBlockApiClientBundle\Http\JsonApiClient;
+use OpenConext\Profile\Value\Arp;
 use OpenConext\Profile\Value\Consent;
 use OpenConext\Profile\Value\ConsentList;
 use OpenConext\Profile\Value\SpecifiedConsent;
@@ -58,6 +59,7 @@ final class AttributeReleasePolicyService
      * @param AttributeSetInterface $attributeSet
      * @return SpecifiedConsentList
      * @SuppressWarnings(PHPMD.NPathComplexity) Build and mapping logic causes complexity
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Build and mapping logic causes complexity
      */
     public function applyAttributeReleasePolicies(ConsentList $consentList, AttributeSetInterface $attributeSet)
     {
@@ -84,10 +86,17 @@ final class AttributeReleasePolicyService
             'attributes' => !empty($mappedAttributes) ? $mappedAttributes : new stdClass(),
             'showSources' => true,
         ];
+        // Arp is applied for all entities
         $response = $this->jsonApiClient->post($data, '/arp');
 
+        $data = [
+            'entityIds'  => $entityIds,
+        ];
+        // Arp information is retrieved for all entities with arp enabled.
+        $arpResponse = $this->jsonApiClient->post($data, '/read-arp');
+
         $specifiedConsents = $consentList->map(
-            function (Consent $consent) use ($response) {
+            function (Consent $consent) use ($response, $arpResponse) {
                 $entityId = $consent->getServiceProvider()->getEntity()->getEntityId()->getEntityId();
 
                 if (!isset($response[$entityId])) {
@@ -113,8 +122,12 @@ final class AttributeReleasePolicyService
                         $attributes[] = $attribute;
                     }
                 }
+                $arp = Arp::createWith([], null);
+                if (isset($arpResponse[$entityId])) {
+                    $arp = Arp::createWith($arpResponse[$entityId], $this->attributeDictionary);
+                }
 
-                return SpecifiedConsent::specifies($consent, AttributeSetWithFallbacks::create($attributes));
+                return SpecifiedConsent::specifies($consent, AttributeSetWithFallbacks::create($attributes), $arp);
             }
         );
 

--- a/src/OpenConext/Profile/Exception/InvalidArpDataException.php
+++ b/src/OpenConext/Profile/Exception/InvalidArpDataException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\Profile\Exception;
+
+class InvalidArpDataException extends InvalidArgumentException
+{
+}

--- a/src/OpenConext/Profile/Tests/Value/ArpTest.php
+++ b/src/OpenConext/Profile/Tests/Value/ArpTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Copyright 2015 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\Profile\Tests\Value;
+
+use DateTimeImmutable;
+use Mockery;
+use OpenConext\Profile\Exception\InvalidArpDataException;
+use OpenConext\Profile\Value\Arp;
+use OpenConext\Profile\Value\Consent;
+use OpenConext\Profile\Value\Consent\ServiceProvider;
+use OpenConext\Profile\Value\ConsentType;
+use OpenConext\Profile\Value\ContactEmailAddress;
+use OpenConext\Profile\Value\DisplayName;
+use OpenConext\Profile\Value\Entity;
+use OpenConext\Profile\Value\EntityId;
+use OpenConext\Profile\Value\EntityType;
+use OpenConext\Profile\Value\SpecifiedConsent;
+use OpenConext\Profile\Value\Url;
+use OpenConext\ProfileBundle\Attribute\AttributeSetWithFallbacks;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+
+class ArpTest extends TestCase
+{
+    public function test_it_can_be_constructed_with_empty_arp_data()
+    {
+        $arp = Arp::createWith([]);
+        $this->assertInstanceOf(Arp::class, $arp);
+        $this->assertEmpty($arp->getAttributesGroupedBySource());
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    /**
+     * @expectedException \OpenConext\Profile\Exception\InvalidArpDataException
+     * @dataProvider invalidArpData
+     */
+    public function test_it_rejects_invalid_data_structures($invalidArpData)
+    {
+        Arp::createWith($invalidArpData);
+    }
+
+    public function test_construction_with_valid_arp_data()
+    {
+        $arp = Arp::createWith(json_decode(file_get_contents(__DIR__ . '/../fixture/arp-response.json'), true));
+        $this->assertInstanceOf(Arp::class, $arp);
+        $attributes = $arp->getAttributesGroupedBySource();
+
+        $this->assertCount(4, $attributes);
+        $this->assertArrayHasKey('idp', $attributes);
+        $this->assertArrayHasKey('sab', $attributes);
+        $this->assertArrayHasKey('voot', $attributes);
+        $this->assertArrayHasKey('orcid', $attributes);
+
+        // All entries should be Attribute instances.
+        foreach ($attributes['idp'] as $attribute) {
+            $this->assertInstanceOf(Attribute::class, $attribute);
+        }
+    }
+
+    public function test_filtering_of_idp_sources()
+    {
+        $arp = Arp::createWith(json_decode(file_get_contents(__DIR__ . '/../fixture/arp-response.json'), true));
+        $this->assertArrayNotHasKey('idp', $arp->getNonIdpAttributes());
+        $this->assertArrayHasKey('idp', $arp->getAttributesGroupedBySource());
+
+        $arp = Arp::createWith([]);
+        $this->assertArrayNotHasKey('idp', $arp->getNonIdpAttributes());
+        $this->assertArrayNotHasKey('idp', $arp->getAttributesGroupedBySource());
+    }
+
+    public function test_dictionary_usage()
+    {
+        // The dictionary is mocked and always returns the same definition.
+        $dictionary = Mockery::mock(AttributeDictionary::class);
+        $bogusDefinition = new AttributeDefinition('Foobar', 'urn.mace.FooBar', '123.323.432.12');
+        $dictionary
+            ->shouldReceive('getAttributeDefinitionByUrn')
+            ->times(13)
+            ->andReturn($bogusDefinition);
+
+        $arp = Arp::createWith(
+            json_decode(file_get_contents(__DIR__ . '/../fixture/arp-response.json'), true),
+            $dictionary
+        );
+
+        // All entries should have the same attribute definition
+        foreach ($arp->getAttributesGroupedBySource()['idp'] as $attribute) {
+            $this->assertEquals($bogusDefinition, $attribute->getAttributeDefinition());
+        }
+    }
+
+    public function invalidArpData()
+    {
+        return [
+            [[null]],
+            [['urn.mace.foobar' => [['invalid-key' => 'foo']]]],
+            [['urn.mace.foobar' => [['invalid-key' => null]]]],
+            [['urn.mace.foobar' => [['source' => new StdClass()]]]],
+            [['urn.mace.foobar' => [['value' => new StdClass()]]]],
+            [['urn.mace.foobar' => [['value' => '*', 'sourcy' => 'fff']]]],
+            [['urn.mace.foobar' => [['value' => '*', 'source' => []]]]],
+            [['urn.mace.foobar' => [['value' => '*'], ['value' => '*', 'source' => []]]]],
+        ];
+    }
+}

--- a/src/OpenConext/Profile/Tests/fixture/arp-response.json
+++ b/src/OpenConext/Profile/Tests/fixture/arp-response.json
@@ -1,0 +1,70 @@
+{
+  "urn:mace:dir:attribute-def:eduPersonTargetedID": [
+    {
+      "value": "*"
+    }
+  ],
+  "urn:mace:dir:attribute-def:eduPersonPrincipalName": [
+    {
+      "value": "*"
+    }
+  ],
+  "urn:mace:dir:attribute-def:displayName": [
+    {
+      "value": "*"
+    }
+  ],
+  "urn:mace:dir:attribute-def:cn": [
+    {
+      "value": "*"
+    }
+  ],
+  "urn:mace:dir:attribute-def:givenName": [
+    {
+      "value": "*"
+    }
+  ],
+  "urn:mace:dir:attribute-def:sn": [
+    {
+      "value": "*"
+    }
+  ],
+  "urn:mace:dir:attribute-def:mail": [
+    {
+      "value": "*"
+    }
+  ],
+  "urn:mace:terena.org:attribute-def:schacHomeOrganization": [
+    {
+      "value": ""
+    }
+  ],
+  "urn:mace:dir:attribute-def:eduPersonAffiliation": [
+    {
+      "value": "filter-value",
+      "source": "voot"
+    }
+  ],
+  "urn:mace:dir:attribute-def:eduPersonOrcid": [
+    {
+      "value": "*",
+      "source": "orcid"
+    }
+  ],
+  "urn:mace:dir:attribute-def:isMemberOf": [
+    {
+      "value": "-",
+      "source": "sab"
+    }
+  ],
+  "urn:mace:dir:attribute-def:uid": [
+    {
+      "value": "*"
+    }
+  ],
+  "urn:mace:dir:attribute-def:preferredLanguage": [
+    {
+      "value": "*"
+    }
+  ]
+}

--- a/src/OpenConext/Profile/Value/Arp.php
+++ b/src/OpenConext/Profile/Value/Arp.php
@@ -134,9 +134,7 @@ final class Arp
     public function getNonIdpAttributes()
     {
         $attributes = $this->getAttributesGroupedBySource();
-        if (isset($attributes['idp'])) {
-            unset($attributes['idp']);
-        }
+        unset($attributes['idp']);
         return $attributes;
     }
 

--- a/src/OpenConext/Profile/Value/Arp.php
+++ b/src/OpenConext/Profile/Value/Arp.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Copyright 2017 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\Profile\Value;
+
+use OpenConext\Profile\Exception\InvalidArpDataException;
+use Surfnet\SamlBundle\Exception\UnknownUrnException;
+use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+
+/**
+ * The Arp value object represents the Arp configuration for a given entity.
+ */
+final class Arp
+{
+    /**
+     * @var array The arp configuration is grouped on source. The source values are a collection of Attribute
+     */
+    private $arp;
+
+    public static function createWith(array $arp, AttributeDictionary $dictionary = null)
+    {
+        // Input validation
+        foreach ($arp as $attributeInformation) {
+            if (!is_array($attributeInformation)) {
+                throw new InvalidArpDataException('The attribute information in the arp should be an array.');
+            }
+            if (!self::isValidAttribute($attributeInformation)) {
+                throw new InvalidArpDataException('The attribute information is formatted invalidly.');
+            }
+        }
+
+        return new self($arp, $dictionary);
+    }
+
+    private function __construct(array $arp, AttributeDictionary $dictionary = null)
+    {
+        $arpCollection = [];
+
+        // Create Attribute instances for all attributes
+        foreach ($arp as $attributeName => $attributeDefinitionInformation) {
+            $attributeSource = 'idp';
+            $attributeDefinition = new AttributeDefinition($attributeName, $attributeName, $attributeName);
+
+            // When the dictionary is available. Lookup the attribute in dictionary to load friendly attribute names
+            if (!is_null($dictionary)) {
+                try {
+                    $attributeDefinition = $dictionary->getAttributeDefinitionByUrn($attributeName);
+                } catch (UnknownUrnException $exception) {
+                    // Use the previously created attributeDefinition.
+                }
+            }
+
+            if (isset($attributeDefinitionInformation[0]['source'])) {
+                $attributeSource = $attributeDefinitionInformation[0]['source'];
+            }
+
+            // The arp is grouped on attribute source
+            $arpCollection[$attributeSource][] = new Attribute($attributeDefinition, $attributeDefinitionInformation);
+        }
+
+        $this->arp = $arpCollection;
+    }
+
+    /**
+     * Tests the structure of the Arp attribute information.
+     *
+     * This information should be an array, should have the attribute names as its keys and have array values.
+     * These array values can have two keys (value & source) the values aof these entries should be string.
+     *
+     * Example of a valid attribute information array:
+     *
+     * [
+     *   'urn.mace.email' => [
+     *     ['value' => '*'],
+     *   ],
+     *   'urn.mace.eduPersonTargetedId' => [
+     *     [
+     *       'value' => '*',
+     *       'source' => 'sab',
+     *     ]
+     *   ],
+     *   'urn.mace.orcid' => [
+     *     [
+     *       'value' => 'orcid.org/\d{4}-\d{4}',
+     *       'source' => 'orcid',
+     *     ],
+     *     [
+     *       'value' => 'sandbox.orcid.org/\d{4}-\d{4}',
+     *       'source' => 'orcid',
+     *     ],
+     *   ],
+     * ]
+     *
+     * @param array $attributeInformation
+     * @return bool
+     */
+    private static function isValidAttribute(array $attributeInformation)
+    {
+        $validKeys = ['value', 'source'];
+
+        foreach ($attributeInformation as $attributeInformationEntry) {
+            foreach ($attributeInformationEntry as $key => $attributeConfigValue) {
+                if (!in_array($key, $validKeys)) {
+                    return false;
+                }
+                if (!is_string($attributeConfigValue)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @return array
+     */
+    public function getNonIdpAttributes()
+    {
+        $attributes = $this->getAttributesGroupedBySource();
+        if (isset($attributes['idp'])) {
+            unset($attributes['idp']);
+        }
+        return $attributes;
+    }
+
+    public function getAttributesGroupedBySource()
+    {
+        return $this->arp;
+    }
+}

--- a/src/OpenConext/Profile/Value/SpecifiedConsent.php
+++ b/src/OpenConext/Profile/Value/SpecifiedConsent.php
@@ -34,23 +34,31 @@ class SpecifiedConsent
     private $releasedAttributes;
 
     /**
+     * @var Arp
+     */
+    private $arp;
+
+    /**
      * @param Consent $consent
      * @param AttributeSet $releasedAttributes
+     * @param Arp $arp
      * @return SpecifiedConsent
      */
-    public static function specifies(Consent $consent, AttributeSet $releasedAttributes)
+    public static function specifies(Consent $consent, AttributeSet $releasedAttributes, Arp $arp)
     {
-        return new self($consent, $releasedAttributes);
+        return new self($consent, $releasedAttributes, $arp);
     }
 
     /**
      * @param Consent $consent
      * @param AttributeSet $releasedAttributes
+     * @param Arp $arp
      */
-    private function __construct(Consent $consent, AttributeSet $releasedAttributes)
+    private function __construct(Consent $consent, AttributeSet $releasedAttributes, Arp $arp)
     {
-        $this->consent            = $consent;
+        $this->consent = $consent;
         $this->releasedAttributes = $releasedAttributes;
+        $this->arp = $arp;
     }
 
     /**
@@ -77,11 +85,14 @@ class SpecifiedConsent
             $sources[$source] = $source;
         }
 
+        $sources = array_merge($sources, $this->arp->getNonIdpAttributes());
+
         return count($sources) > 1;
     }
 
     /**
-     * Groups the released attributes on the group they originate from. This can be used to show the attributes.
+     * Groups the released attributes on the group they originate from. This can be used to show the AA attributes.
+     * Note that the attributes from the IdP source are omitted in the results.
      *
      * @return Attribute[]
      */
@@ -91,8 +102,14 @@ class SpecifiedConsent
         foreach ($this->getReleasedAttributes() as $attribute) {
             // The source is the same for all possible attribute values, so use the first one.
             $source = $attribute->getValue()[0]['source'];
+            if ($source !== 'idp') {
+                continue;
+            }
+
             $grouped[$source][] = $attribute;
         }
+        $grouped = array_merge($grouped, $this->arp->getNonIdpAttributes());
+
         return $grouped;
     }
 }

--- a/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
+++ b/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
@@ -144,16 +144,11 @@ class AttributeReleasePolicyServiceTest extends TestCase
             ],
         ];
 
-        $client->shouldReceive('post')
+        $client->shouldReceive('read')
             ->withArgs(
                 [
-                    [
-                        'entityIds'  => [
-                            'some-entity-id',
-                            'another-entity-id'
-                        ]
-                    ],
-                    '/read-arp',
+                    '/read-arp?entityIds=%s',
+                    ['some-entity-id,another-entity-id'],
                 ]
             )
             ->andReturn($arpData);

--- a/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
+++ b/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
@@ -22,6 +22,7 @@ use DateTimeImmutable;
 use Mockery;
 use OpenConext\EngineBlockApiClientBundle\Http\JsonApiClient;
 use OpenConext\EngineBlockApiClientBundle\Service\AttributeReleasePolicyService;
+use OpenConext\Profile\Value\Arp;
 use OpenConext\Profile\Value\Consent;
 use OpenConext\Profile\Value\Consent\ServiceProvider;
 use OpenConext\Profile\Value\ConsentList;
@@ -112,6 +113,51 @@ class AttributeReleasePolicyServiceTest extends TestCase
                 ],
             ]);
 
+        $arpData = [
+            'some-entity-id' => [
+                'urn:mace:some-attribute' => [
+                    [
+                        'value' => 'some-value',
+                        'source' => 'idp',
+                    ],
+                ],
+                'urn:oid:0.0.0.0.0.1' => [
+                    [
+                        'value' => 'some-value',
+                        'source' => 'idp',
+                    ],
+                ],
+                'urn:oid:0.0.0.0.0.2' => [
+                    [
+                        'value' => 'another-value',
+                        'source' => 'sab',
+                    ],
+                ],
+            ],
+            'another-entity-id' => [
+                'urn:oid:0.0.0.0.0.2' => [
+                    [
+                        'value' => 'another-value',
+                        'source' => 'voot',
+                    ],
+                ]
+            ],
+        ];
+
+        $client->shouldReceive('post')
+            ->withArgs(
+                [
+                    [
+                        'entityIds'  => [
+                            'some-entity-id',
+                            'another-entity-id'
+                        ]
+                    ],
+                    '/read-arp',
+                ]
+            )
+            ->andReturn($arpData);
+
         $someConsent = new Consent(
             new ServiceProvider(
                 new Entity(
@@ -155,9 +201,14 @@ class AttributeReleasePolicyServiceTest extends TestCase
         $expectedResult = SpecifiedConsentList::createWith([
             SpecifiedConsent::specifies(
                 $someConsent,
-                AttributeSetWithFallbacks::create([$expectedSomeAttribute, $expectedAnotherAttribute])
+                AttributeSetWithFallbacks::create([$expectedSomeAttribute, $expectedAnotherAttribute]),
+                Arp::createWith($arpData['some-entity-id'], $attributeDictionary)
             ),
-            SpecifiedConsent::specifies($anotherConsent, AttributeSetWithFallbacks::create([$expectedAnotherAttribute]))
+            SpecifiedConsent::specifies(
+                $anotherConsent,
+                AttributeSetWithFallbacks::create([$expectedAnotherAttribute]),
+                Arp::createWith($arpData['another-entity-id'], $attributeDictionary)
+            )
         ]);
 
         $result = $arpService->applyAttributeReleasePolicies($consentList, $attributeSet);


### PR DESCRIPTION
**Test notes**
Enable ARP for an SP you can use (I've used teams). And set sources different than idp on some of the attributes. Log in to the service you just modified and then check the my services page in Profile. 

Update your EB installation by checking out the `feature/eb-api-read-arp-endpoint` feature branch.

A new release for the Saml bundle was released and installed (2.11.2). Make sure you update your composer dependencies.

**Work checklist**
- [x] Update EB API to be able to retrieve Arp config for SP entities
- [x] Update StepupSamlBundle to add support for the ORCiD ID attribute (Dictionary config)
- [x] Refactor my services related logic