### PR TITLE
Add AA source support for SURFmarked Entitlements

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,29 @@ can be done on an installation that runs in `DEV` mode. Make sure you log
 into profile at `https://profile-dev.vm.openconext.org`. Then go to
 `https://profile.vm.openconext.org/app_dev.php/_trans/` to update the strings.
 
+## Common tasks
+
+### Add support for new Attribute Aggregation source
+In EngineBlock ARP, attributes can be derived from a source other than the IdP. Whenever a source other than
+the IdP is configured. Profile will not (yet) attempt to retrieve the value for that attribute. But will show only a
+summation of the attribute names for each given source. 
+
+When a new source is added in the Service Registry (or Manage) it must also be added to Profile.  
+1. Add translation entry in `translations.html.twig`. At the bottom of the file:
+    ```twig
+    {{ 'profile.table.source_description.voot'|trans }}
+    {{ 'profile.table.source_description.orcid'|trans }}
+    {{ 'profile.table.source_description.sab'|trans }}
+    
+    {# Add your new source here, make sure the source name complies with the sourcename specified in the service registry. #}
+    ```
+2. Extract the new translation and translate them in the available `messages.LANG.xliff` translation files.
+3. Done.
+
+To test your change. Modify one of the SP's already present in the 'My Services' overview with the newly added source. 
+Do this by changing the source of one of the attributes to the newly added source. You might need to add the source to 
+the SR/Manage configuration first. 
+
 # License
 This project is licensed under version 2.0 of the Apache License, as described
 in the file [LICENSE](LICENSE).

--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -490,6 +490,11 @@ This profile page gives you insight in which personal data, provided by your ins
         <target>SURFnet Autorisatie Beheer</target>
         <jms:reference-file line="176">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="0fcd10ec6755193c6f51f1c0377f950eca8b02d3" resname="profile.table.source_description.surfmarket-entitlements">
+        <source>profile.table.source_description.surfmarket-entitlements</source>
+        <target>SURFmarket Entitlements</target>
+        <jms:reference-file line="177">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="4b1c5ddcfd432d3477264f068b21ff7996915e06" resname="profile.table.source_description.voot">
         <source>profile.table.source_description.voot</source>
         <target>Group membership</target>

--- a/app/Resources/translations/messages.nl.xliff
+++ b/app/Resources/translations/messages.nl.xliff
@@ -490,6 +490,11 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
         <target>SURFnet Autorisatie Beheer</target>
         <jms:reference-file line="176">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="0fcd10ec6755193c6f51f1c0377f950eca8b02d3" resname="profile.table.source_description.surfmarket-entitlements">
+        <source>profile.table.source_description.surfmarket-entitlements</source>
+        <target>SURFmarket Entitlements</target>
+        <jms:reference-file line="177">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+      </trans-unit>
       <trans-unit id="4b1c5ddcfd432d3477264f068b21ff7996915e06" resname="profile.table.source_description.voot">
         <source>profile.table.source_description.voot</source>
         <target>Groepslidmaatschap</target>

--- a/src/OpenConext/ProfileBundle/Resources/views/translations.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/translations.html.twig
@@ -174,3 +174,4 @@
 {{ 'profile.table.source_description.voot'|trans }}
 {{ 'profile.table.source_description.orcid'|trans }}
 {{ 'profile.table.source_description.sab'|trans }}
+{{ 'profile.table.source_description.surfmarket-entitlements'|trans }}


### PR DESCRIPTION
The source name was added to the translations. And a readme entry was 

I've added a brief summary of this task to the readme as adding AA sources might become a common task in the future.