### PR TITLE
Feature/rework orcid disconnect button

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ open_conext_profile:
     
     attribute_aggregation_supported_attributes:
         # The identifier of the attribute, should match the Attribute Aggregation API's definition
-        orcid:
+        ORCID:
             # The relative path to an image. Starting from the /web folder
             logo_path: %attribute_aggregation_orcid_logo_path%
             # The Url where the attribute can be connected

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ below.
 version: https://profile-dev.vm.openconext.org and the OpenConext-deploy pre-installed
 version available at: https://profile.vm.openconext.org.
 
+In order for the profile VM to be able to access the OpenConext-deploy
+VM, you need to modify the hosts file of the profile VM and point the
+EngineBlock and aggregator (AA) hostnames to the loadbalancer VM:
+
+    192.168.66.98 engine-api.vm.openconext.org aa.vm.openconext.org
+
 ### Configure Profile as SP in service registry
 
  1. Visit https://serviceregistry.vm.openconext.org/

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ open_conext_profile:
             logo_path: %attribute_aggregation_orcid_logo_path%
             # The Url where the attribute can be connected
             connect_url: %attribute_aggregation_orcid_connect_url%
-            # The Url where the attribute can be disconnected
-            disconnect_url: %attribute_aggregation_orcid_disconnect_url%
 ```
 
 ## Releases

--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-09T16:45:26Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2018-01-11T10:01:27Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -61,6 +61,16 @@
         <source>profile.attribute_support_confirmation.short_title</source>
         <target>Attribute data mailed</target>
         <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="2e799f3107a8bb43962025dfc3883e9b7ac96d41" resname="profile.confirm_connection_delete.confirm">
+        <source>profile.confirm_connection_delete.confirm</source>
+        <target>Confirm</target>
+        <jms:reference-file line="50">/../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="757f129ed6459928baf538b9c6947626808aee49" resname="profile.confirm_connection_delete.confirm_label">
+        <source>profile.confirm_connection_delete.confirm_label</source>
+        <target>I agree to disconnect this connection.</target>
+        <jms:reference-file line="42">/../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="635d3df5bf4d25f2ba2aa31d49a7b66a18a78d59" resname="profile.information_request.explanation">
         <source>profile.information_request.explanation</source>
@@ -158,90 +168,90 @@ This profile page gives you insight in which personal data, provided by your ins
       <trans-unit id="9efb18562f68975294c34a9d578af71915151cc5" resname="profile.my_connections.active_connections">
         <source>profile.my_connections.active_connections</source>
         <target>Active connections</target>
-        <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b45e0cbe033a9a0c1c9ca4f86be6bfe4c30f7681" resname="profile.my_connections.available_connections">
         <source>profile.my_connections.available_connections</source>
         <target>Available Connections</target>
-        <jms:reference-file line="50">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="56">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5786ea6a363e616a432c6c437314c328dbdca83c" resname="profile.my_connections.description_label">
         <source>profile.my_connections.description_label</source>
         <target>Description</target>
-        <jms:reference-file line="64">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="70">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dabc34079097e6ea7a29934f274e65a91e95f82a" resname="profile.my_connections.explanation">
         <source>profile.my_connections.explanation</source>
         <target>It's possible to connect external sources to your SURFconext profile. SURFconext can use this information to enrich the existing attributes of your institutional account with the values from this external account. Services connected to SURFconext can receive and use this information.</target>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="287927bbc9031325f1d5a3efeb26577352fe68f9" resname="profile.my_connections.long_title">
         <source>profile.my_connections.long_title</source>
         <target>Accounts linked to your profile</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="34ce48e722c206f299190088acea1e55ba420e99" resname="profile.my_connections.missing_connections">
         <source>profile.my_connections.missing_connections</source>
         <target>Missing Connections?</target>
-        <jms:reference-file line="80">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="86">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d8030c905e3901505ffa45585843d95d71cedb7a" resname="profile.my_connections.no_active_connections.description">
         <source>profile.my_connections.no_active_connections.description</source>
         <target>You don't have any active connections yet.</target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ec33c82bf179989652928e2df38fcf975c378d95" resname="profile.my_connections.no_connections_configured.description">
         <source>profile.my_connections.no_connections_configured.description</source>
         <target>At the moment there are no connections that are available for configuration.</target>
-        <jms:reference-file line="52">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="58">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d1a92495d8e08cf89bf517af5ffe5461407d2921" resname="profile.my_connections.orcid.connect_title">
         <source>profile.my_connections.orcid.connect_title</source>
         <target>Connect</target>
-        <jms:reference-file line="72">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="78">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c4b69512880a8532d9740e870ed8a60b8791b3bc" resname="profile.my_connections.orcid.description">
         <source>profile.my_connections.orcid.description</source>
         <target>ORCID is a nonproprietary alphanumeric code to uniquely identify scientific and other academic authors. This addresses the problem that a particular author's contributions to the scientific literature or publications in the humanities can be hard to recognize as most personal names are not unique, they can change (such as with marriage), have cultural differences in name order, contain inconsistent use of first-name abbreviations and employ different writing systems.</target>
-        <jms:reference-file line="65">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4bc8f1ebcd9026ebbc6df9e128e3a1c0d4407ebd" resname="profile.my_connections.orcid.disconnect_title">
         <source>profile.my_connections.orcid.disconnect_title</source>
         <target>Disconnect</target>
-        <jms:reference-file line="38">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bd50bc94d1957cd597c43c9a1eb6284461d48482" resname="profile.my_connections.orcid.status">
         <source>profile.my_connections.orcid.status</source>
         <target>Status</target>
-        <jms:reference-file line="29">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f36591d6cd52fa2b3b097b9cd4ca900700fe22e" resname="profile.my_connections.orcid.status_connected">
         <source>profile.my_connections.orcid.status_connected</source>
         <target>Connected</target>
-        <jms:reference-file line="30">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb0b77c5fd95698ab75dbd35962d63c0e76e9f2c" resname="profile.my_connections.orcid.title">
         <source>profile.my_connections.orcid.title</source>
         <target>ORCID</target>
-        <jms:reference-file line="22">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="25">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="61">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="27">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="30">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="67">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d8ba5b858f788ea3b20782b6d6a2653ab34581c" resname="profile.my_connections.send_request">
         <source>profile.my_connections.send_request</source>
         <target>Send us a request</target>
-        <jms:reference-file line="81">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="87">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d19d7e654594f5a24af2d7ccd23a3678082a0db4" resname="profile.my_connections.service_label">
         <source>profile.my_connections.service_label</source>
         <target>Service</target>
-        <jms:reference-file line="21">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="60">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="66">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f61fad44caa0beb389084eb69cd3663855a1a3ac" resname="profile.my_connections.short_title">
         <source>profile.my_connections.short_title</source>
         <target>My Connections</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
         <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b172b6b32cc00171f63b2834d2710be9a0e882fd" resname="profile.my_profile.attributes_information_link_title">
@@ -490,7 +500,7 @@ This profile page gives you insight in which personal data, provided by your ins
         <target>SURFnet Autorisatie Beheer</target>
         <jms:reference-file line="176">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="0fcd10ec6755193c6f51f1c0377f950eca8b02d3" resname="profile.table.source_description.surfmarket-entitlements">
+      <trans-unit id="7eaa211c78eb7290993519c729e4e05c49269da3" resname="profile.table.source_description.surfmarket-entitlements">
         <source>profile.table.source_description.surfmarket-entitlements</source>
         <target>SURFmarket Entitlements</target>
         <jms:reference-file line="177">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>

--- a/app/Resources/translations/messages.nl.xliff
+++ b/app/Resources/translations/messages.nl.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-09T16:45:54Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
+  <file date="2018-01-11T10:01:28Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -60,6 +60,16 @@
         <source>profile.attribute_support_confirmation.short_title</source>
         <target>Attribuutdata gemaild</target>
         <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="2e799f3107a8bb43962025dfc3883e9b7ac96d41" resname="profile.confirm_connection_delete.confirm">
+        <source>profile.confirm_connection_delete.confirm</source>
+        <target>Toepassen</target>
+        <jms:reference-file line="50">/../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="757f129ed6459928baf538b9c6947626808aee49" resname="profile.confirm_connection_delete.confirm_label">
+        <source>profile.confirm_connection_delete.confirm_label</source>
+        <target>Ja, verwijder deze koppeling</target>
+        <jms:reference-file line="42">/../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="635d3df5bf4d25f2ba2aa31d49a7b66a18a78d59" resname="profile.information_request.explanation">
         <source>profile.information_request.explanation</source>
@@ -158,90 +168,90 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
       <trans-unit id="9efb18562f68975294c34a9d578af71915151cc5" resname="profile.my_connections.active_connections">
         <source>profile.my_connections.active_connections</source>
         <target>Actieve koppelingen</target>
-        <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b45e0cbe033a9a0c1c9ca4f86be6bfe4c30f7681" resname="profile.my_connections.available_connections">
         <source>profile.my_connections.available_connections</source>
         <target>Beschikbare koppelingen</target>
-        <jms:reference-file line="50">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="56">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5786ea6a363e616a432c6c437314c328dbdca83c" resname="profile.my_connections.description_label">
         <source>profile.my_connections.description_label</source>
         <target>Omschrijving</target>
-        <jms:reference-file line="64">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="70">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dabc34079097e6ea7a29934f274e65a91e95f82a" resname="profile.my_connections.explanation">
         <source>profile.my_connections.explanation</source>
         <target>Je kunt externe bronnen koppelen aan je SURFconext-profiel. SURFconext kan deze gegevens gebruiken om je bestaande attributen afkomstig van je instellingsaccount te verrijken met de waarden uit het gekoppelde account. Diensten die verbonden zijn met SURFconext kunnen vervolgens deze informatie ontvangen.</target>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="287927bbc9031325f1d5a3efeb26577352fe68f9" resname="profile.my_connections.long_title">
         <source>profile.my_connections.long_title</source>
         <target>Accounts gelinkt aan je profiel</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="34ce48e722c206f299190088acea1e55ba420e99" resname="profile.my_connections.missing_connections">
         <source>profile.my_connections.missing_connections</source>
         <target>Missende koppelingen?</target>
-        <jms:reference-file line="80">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="86">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d8030c905e3901505ffa45585843d95d71cedb7a" resname="profile.my_connections.no_active_connections.description">
         <source>profile.my_connections.no_active_connections.description</source>
         <target>Je hebt nog geen actieve koppelingen.</target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ec33c82bf179989652928e2df38fcf975c378d95" resname="profile.my_connections.no_connections_configured.description">
         <source>profile.my_connections.no_connections_configured.description</source>
         <target>Op dit moment zijn er geen koppelingen beschikbaar die geconfigureerd kunnen worden.</target>
-        <jms:reference-file line="52">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="58">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d1a92495d8e08cf89bf517af5ffe5461407d2921" resname="profile.my_connections.orcid.connect_title">
         <source>profile.my_connections.orcid.connect_title</source>
         <target>Koppelen</target>
-        <jms:reference-file line="72">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="78">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c4b69512880a8532d9740e870ed8a60b8791b3bc" resname="profile.my_connections.orcid.description">
         <source>profile.my_connections.orcid.description</source>
         <target>ORCID is een alpha-numerieke code die wordt gebruikt om auteurs van wetenschappelijke werken uniek te identificeren.</target>
-        <jms:reference-file line="65">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4bc8f1ebcd9026ebbc6df9e128e3a1c0d4407ebd" resname="profile.my_connections.orcid.disconnect_title">
         <source>profile.my_connections.orcid.disconnect_title</source>
         <target>Ontkoppelen</target>
-        <jms:reference-file line="38">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bd50bc94d1957cd597c43c9a1eb6284461d48482" resname="profile.my_connections.orcid.status">
         <source>profile.my_connections.orcid.status</source>
         <target>Status</target>
-        <jms:reference-file line="29">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f36591d6cd52fa2b3b097b9cd4ca900700fe22e" resname="profile.my_connections.orcid.status_connected">
         <source>profile.my_connections.orcid.status_connected</source>
         <target>Gekoppeld</target>
-        <jms:reference-file line="30">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb0b77c5fd95698ab75dbd35962d63c0e76e9f2c" resname="profile.my_connections.orcid.title">
         <source>profile.my_connections.orcid.title</source>
         <target>ORCID</target>
-        <jms:reference-file line="22">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="25">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="61">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="27">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="30">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="67">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d8ba5b858f788ea3b20782b6d6a2653ab34581c" resname="profile.my_connections.send_request">
         <source>profile.my_connections.send_request</source>
         <target>Stuur ons een verzoek</target>
-        <jms:reference-file line="81">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="87">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d19d7e654594f5a24af2d7ccd23a3678082a0db4" resname="profile.my_connections.service_label">
         <source>profile.my_connections.service_label</source>
         <target>Service</target>
-        <jms:reference-file line="21">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="60">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="66">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f61fad44caa0beb389084eb69cd3663855a1a3ac" resname="profile.my_connections.short_title">
         <source>profile.my_connections.short_title</source>
         <target>Mijn koppelingen</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
         <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b172b6b32cc00171f63b2834d2710be9a0e882fd" resname="profile.my_profile.attributes_information_link_title">
@@ -490,7 +500,7 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
         <target>SURFnet Autorisatie Beheer</target>
         <jms:reference-file line="176">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="0fcd10ec6755193c6f51f1c0377f950eca8b02d3" resname="profile.table.source_description.surfmarket-entitlements">
+      <trans-unit id="7eaa211c78eb7290993519c729e4e05c49269da3" resname="profile.table.source_description.surfmarket-entitlements">
         <source>profile.table.source_description.surfmarket-entitlements</source>
         <target>SURFmarket Entitlements</target>
         <jms:reference-file line="177">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -145,5 +145,3 @@ open_conext_profile:
             logo_path: %attribute_aggregation_orcid_logo_path%
             # The Url where the attribute can be connected
             connect_url: %attribute_aggregation_orcid_connect_url%
-            # The Url where the attribute can be disconnected
-            disconnect_url: %attribute_aggregation_orcid_disconnect_url%

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -30,7 +30,6 @@ parameters:
     # orcid aa attribute settings for orcid
     attribute_aggregation_orcid_logo_path: '/images/orcid.png'
     attribute_aggregation_orcid_connect_url: 'https://link.surfconext.nl/orcid?redirectUrl=https://profile.surfconext.nl/my-connections'
-    attribute_aggregation_orcid_disconnect_url: 'https://link.surfconext.nl/orcid?redirectUrl=https://profile.surfconext.nl/my-connections'
 
     mailer_transport:  sendmail
     mailer_host:       ~

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -22,7 +22,7 @@ parameters:
     engineblock_api_password: secret
     engineblock_api_verify_ssl: true
 
-    attribute_aggregation_api_base_url: 'https://aa.vm.openconext.org/aa/api/internal/accounts/'
+    attribute_aggregation_api_base_url: 'https://aa.vm.openconext.org/aa/api/internal/'
     attribute_aggregation_api_username: eb
     attribute_aggregation_api_password: secret
     attribute_aggregation_api_verify_ssl: true

--- a/src/OpenConext/AttributeAggregationApiClientBundle/Http/JsonApiClient.php
+++ b/src/OpenConext/AttributeAggregationApiClientBundle/Http/JsonApiClient.php
@@ -52,9 +52,29 @@ class JsonApiClient
      */
     public function read($path, array $parameters = [])
     {
+        return $this->handle('GET', $path, $parameters);
+    }
+
+    /**
+     * @param string $path A URL path, optionally containing printf parameters. The parameters
+     *               will be URL encoded and formatted into the path string.
+     *               Example: "connections/%d.json"
+     * @param array  $parameters
+     * @return mixed $data
+     * @throws InvalidResponseException
+     * @throws MalformedResponseException
+     * @throws ResourceNotFoundException
+     */
+    public function delete($path, array $parameters = [])
+    {
+        return $this->handle('DELETE', $path, $parameters);
+    }
+
+    private function handle($method, $path, array $parameters = [])
+    {
         $resource = $this->buildResourcePath($path, $parameters);
 
-        $response = $this->httpClient->request('GET', $resource, ['exceptions' => false]);
+        $response = $this->httpClient->request($method, $resource, ['exceptions' => false]);
 
         $statusCode = $response->getStatusCode();
 

--- a/src/OpenConext/AttributeAggregationApiClientBundle/Repository/AttributeAggregationRepository.php
+++ b/src/OpenConext/AttributeAggregationApiClientBundle/Repository/AttributeAggregationRepository.php
@@ -40,8 +40,17 @@ final class AttributeAggregationRepository implements AttributeAggregationReposi
     {
         Assert::string($surfConextId->getSurfConextId(), 'SurfConext ID "%s" expected to be string, type %s given.');
 
-        $attributes = $this->apiClient->read('%s', [$surfConextId->getSurfConextId()]);
+        $attributes = $this->apiClient->read('accounts/%s', [$surfConextId->getSurfConextId()]);
 
         return AttributeAggregationAttributesList::fromApiResponse($attributes);
+    }
+
+    public function unsubscribeAccount($accountId)
+    {
+        Assert::integer($accountId, 'Account id "%s" expected to be string, type %s given.');
+
+        $result = $this->apiClient->delete('disconnect/%d', [$accountId]);
+
+        return isset($result->status) && $result->status === 'OK';
     }
 }

--- a/src/OpenConext/Profile/Repository/AttributeAggregationRepository.php
+++ b/src/OpenConext/Profile/Repository/AttributeAggregationRepository.php
@@ -30,4 +30,13 @@ interface AttributeAggregationRepository
      * @throws InvalidArgumentException When $userId is not a non-empty string
      */
     public function findAllFor(SurfConextId $userId);
+
+    /**
+     * Removes an account by providing the account id. The method returns a boolean value reflecting the
+     * result of the API call.
+     *
+     * @param $accountId
+     * @return bool
+     */
+    public function unsubscribeAccount($accountId);
 }

--- a/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttribute.php
+++ b/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttribute.php
@@ -23,6 +23,16 @@ use Assert\Assertion;
 final class AttributeAggregationAttribute
 {
     /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $surfconextId;
+
+    /**
      * @var string
      */
     private $accountType;
@@ -43,16 +53,13 @@ final class AttributeAggregationAttribute
     private $connectUrl;
 
     /**
-     * @var string
-     */
-    private $disconnectUrl;
-
-    /**
      * @var bool
      */
     private $isConnected = false;
 
     /**
+     * @param int $id
+     * @param $surfconextId
      * @param string $accountType
      * @param string $linkedId
      * @param string $logoPath
@@ -60,12 +67,16 @@ final class AttributeAggregationAttribute
      * @param bool $isConnected
      */
     public function __construct(
+        $id,
+        $surfconextId,
         $accountType,
         $linkedId,
         $logoPath,
         $connectUrl,
         $isConnected
     ) {
+        $this->id = $id;
+        $this->surfconextId = $surfconextId;
         $this->accountType = $accountType;
         $this->linkedId = $linkedId;
         $this->logoPath = $logoPath;
@@ -76,9 +87,13 @@ final class AttributeAggregationAttribute
     public static function fromConfig(
         AttributeAggregationAttributeConfiguration $enabledAttribute,
         $isConnected,
+        $id,
+        $surfconextId,
         $linkedId = null
     ) {
         return new self(
+            $id,
+            $surfconextId,
             $enabledAttribute->getAccountType(),
             $linkedId,
             $enabledAttribute->getLogoPath(),
@@ -89,6 +104,12 @@ final class AttributeAggregationAttribute
 
     public static function fromApiResponse(array $attributeData)
     {
+        Assertion::keyExists($attributeData, 'id', 'No id found on attribute');
+        Assertion::integer($attributeData['id'], 'Id should be integer');
+
+        Assertion::keyExists($attributeData, 'urn', 'No SURFconext Id found on attribute');
+        Assertion::string($attributeData['urn'], 'SURFconext Id should be a string');
+
         Assertion::keyExists($attributeData, 'accountType', 'No account type found on attribute');
         Assertion::string($attributeData['accountType'], 'Account type should be a string');
 
@@ -96,6 +117,8 @@ final class AttributeAggregationAttribute
         Assertion::string($attributeData['linkedId'], 'Linked id should be a string');
 
         return new self(
+            $attributeData['id'],
+            $attributeData['urn'],
             $attributeData['accountType'],
             $attributeData['linkedId'],
             '',
@@ -138,18 +161,23 @@ final class AttributeAggregationAttribute
     }
 
     /**
-     * @return string
-     */
-    public function getDisconnectUrl()
-    {
-        return $this->disconnectUrl;
-    }
-
-    /**
      * @return bool
      */
     public function isConnected()
     {
         return $this->isConnected;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getSurfconextId()
+    {
+        return $this->surfconextId;
     }
 }

--- a/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttribute.php
+++ b/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttribute.php
@@ -57,7 +57,6 @@ final class AttributeAggregationAttribute
      * @param string $linkedId
      * @param string $logoPath
      * @param string $connectUrl
-     * @param string $disconnectUrl
      * @param bool $isConnected
      */
     public function __construct(
@@ -65,14 +64,12 @@ final class AttributeAggregationAttribute
         $linkedId,
         $logoPath,
         $connectUrl,
-        $disconnectUrl,
         $isConnected
     ) {
         $this->accountType = $accountType;
         $this->linkedId = $linkedId;
         $this->logoPath = $logoPath;
         $this->connectUrl = $connectUrl;
-        $this->disconnectUrl = $disconnectUrl;
         $this->isConnected = $isConnected;
     }
 
@@ -86,7 +83,6 @@ final class AttributeAggregationAttribute
             $linkedId,
             $enabledAttribute->getLogoPath(),
             $enabledAttribute->getConnectUrl(),
-            $enabledAttribute->getDisconnectUrl(),
             $isConnected
         );
     }

--- a/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttributeConfiguration.php
+++ b/src/OpenConext/Profile/Value/AttributeAggregation/AttributeAggregationAttributeConfiguration.php
@@ -36,22 +36,15 @@ final class AttributeAggregationAttributeConfiguration
     private $connectUrl;
 
     /**
-     * @var string
-     */
-    private $disconnectUrl;
-
-    /**
      * @param string $accountType
      * @param string $logoPath
      * @param string $connectUrl
-     * @param string $disconnectUrl
      */
-    public function __construct($accountType, $logoPath, $connectUrl, $disconnectUrl)
+    public function __construct($accountType, $logoPath, $connectUrl)
     {
         $this->accountType = $accountType;
         $this->logoPath = $logoPath;
         $this->connectUrl = $connectUrl;
-        $this->disconnectUrl = $disconnectUrl;
     }
 
     public static function fromConfig($accountType, $attributeConfigParameters)
@@ -59,8 +52,7 @@ final class AttributeAggregationAttributeConfiguration
         return new self(
             $accountType,
             $attributeConfigParameters['logo_path'],
-            $attributeConfigParameters['connect_url'],
-            $attributeConfigParameters['disconnect_url']
+            $attributeConfigParameters['connect_url']
         );
     }
 
@@ -86,13 +78,5 @@ final class AttributeAggregationAttributeConfiguration
     public function getConnectUrl()
     {
         return $this->connectUrl;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDisconnectUrl()
-    {
-        return $this->disconnectUrl;
     }
 }

--- a/src/OpenConext/ProfileBundle/DependencyInjection/Configuration.php
+++ b/src/OpenConext/ProfileBundle/DependencyInjection/Configuration.php
@@ -209,16 +209,6 @@ class Configuration implements ConfigurationInterface
                         ->thenInvalid('The connect url of the AA attribute should be a string')
                     ->end()
                 ->end()
-                ->scalarNode('disconnect_url')
-                    ->info('The disconnect url of the AA attribute')
-                    ->isRequired()
-                    ->validate()
-                        ->ifTrue(function ($disconnectUrl) {
-                            return !is_string($disconnectUrl);
-                        })
-                        ->thenInvalid('The disconnect url of the AA attribute should be a string')
-                    ->end()
-                ->end()
             ->end();
     }
 

--- a/src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php
+++ b/src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\ProfileBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ConfirmConnectionDeleteType extends AbstractType
+{
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'confirmed',
+                'checkbox',
+                [
+                    'attr' => ['class' => 'mdl-checkbox__input confirmation'],
+                    'label' => 'profile.confirm_connection_delete.confirm_label',
+                    'label_attr' => ['class' => 'confirmation-label'],
+                    'empty_data' => false,
+                    'required' => true,
+                ]
+            )
+            ->add(
+                'confirm-button',
+                'submit',
+                [
+                    'attr' => [
+                        'class' => 'mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect ' .
+                                   'mdl-button--accent confirm-button',
+                        'disabled' => 'disabled',
+                    ],
+                    'label' => 'profile.confirm_connection_delete.confirm',
+                ]
+            );
+    }
+
+    public function getName()
+    {
+        return 'profile_confirm_connection_delete';
+    }
+}

--- a/src/OpenConext/ProfileBundle/Resources/config/controllers.yml
+++ b/src/OpenConext/ProfileBundle/Resources/config/controllers.yml
@@ -40,6 +40,8 @@ services:
             - @profile.service.attribute_aggregation
             - @profile.provider.authenticated_user
             - @profile.attribute_support.email_to
+            - @form.factory
+            - @router
 
     profile.controller.locale:
         class: OpenConext\ProfileBundle\Controller\LocaleController

--- a/src/OpenConext/ProfileBundle/Resources/config/routing.yml
+++ b/src/OpenConext/ProfileBundle/Resources/config/routing.yml
@@ -28,7 +28,7 @@ profile.my_services_overview:
 
 profile.my_connections_overview:
     path:       /my-connections
-    methods:    [GET]
+    methods:    [GET,POST]
     schemes:    https
     defaults:
         _controller: profile.controller.my_connections:overviewAction

--- a/src/OpenConext/ProfileBundle/Resources/config/services.yml
+++ b/src/OpenConext/ProfileBundle/Resources/config/services.yml
@@ -81,6 +81,13 @@ services:
         tags:
             - { name: form.type, alias: profile_information_request_mail }
 
+    profile.form.confirm_connection_delete:
+        class: OpenConext\ProfileBundle\Form\Type\ConfirmConnectionDeleteType
+        arguments:
+            - @router
+        tags:
+            - { name: form.type, alias: profile_confirm_connection_delete }
+
     profile.twig.locale_extension:
         public: false
         class: OpenConext\ProfileBundle\Twig\LocaleExtension

--- a/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
@@ -1,5 +1,10 @@
 {% extends 'OpenConextProfileBundle::layout.html.twig' %}
 
+{% block javascripts %}
+    {{ parent() }}
+    <script src="{{ asset('js/my-connections.js') }}"></script>
+{% endblock %}
+
 {% block title %}
     {{ 'profile.my_connections.short_title'|trans }} &mdash; {{ parent() }}
 {% endblock %}
@@ -31,12 +36,13 @@
                     </div>
                     <div class="mdl-cell mdl-cell--3-col">
 
-                        <a
-                            class="mdl-button mdl-js-button mdl-button--raised disconnect"
-                            target="_blank"
-                            href="{{ connection.disconnectUrl }}">
+                        <button class="mdl-button mdl-js-button mdl-button--raised disconnect">
                             {{ 'profile.my_connections.orcid.disconnect_title'|trans }}
-                        </a>
+                        </button>
+
+                        {{ form_start(confirmForm, {attr: {'class': 'confirmation-container', 'novalidate': 'novalidate'} }) }}
+                            {{ form_widget(confirmForm) }}
+                        {{ form_end(confirmForm) }}
 
                     </div>
                 </div>

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -325,9 +325,28 @@ tr.service:hover {
     text-decoration: none;
 }
 
-.attribute-container .mdl-grid .mdl-cell a.mdl-button.disconnect {
+.attribute-container .mdl-grid .mdl-cell button.mdl-button.disconnect {
     background-color: #a9a9a9;
     color: #ffffff;
+}
+
+.confirmation-container {
+    display: none;
+}
+
+.confirmation-container div {
+    clear: both;
+}
+
+.confirmation-container input.confirmation {
+    float: left;
+}
+.confirmation-container label.confirmation-label {
+    margin-left: 5px;
+    font-weight: 500;
+}
+.confirmation-container button.mdl-button {
+    margin-top: 10px;
 }
 
 /* Footer */

--- a/web/js/my-connections.js
+++ b/web/js/my-connections.js
@@ -1,0 +1,19 @@
+$(document).on('click', 'button.disconnect', function (e) {
+    var button = $(e.target),
+        form = $('form.confirmation-container');
+
+    button.hide(200, function(){
+        form.show(200);
+    });
+});
+
+$(document).on('change', 'input.confirmation', function(e) {
+    var checkbox = $(e.target),
+       button = $('button.confirm-button');
+
+    if (checkbox.is(':checked') === true) {
+       button.attr('disabled', false);
+    } else {
+       button.attr('disabled', true);
+    }
+});


### PR DESCRIPTION
**Test notes**
Some config changes in parameters.yml:
* `attribute_aggregation_api_base_url` should be changed to: `https://aa.vm.openconext.org/aa/api/internal/`
* `attribute_aggregation_orcid_disconnect_url`: can be removed from parameters.yml

To test this feature you could create an ORCiD connection by adding an account entry in the `aa-server` database.

```SQL
INSERT INTO `aaserver`.`accounts` (`id`, `urn`, `account_type`, `linked_id`, `created`, `schac_home`) VALUES ('1', 'urn:collab:person:example.com:student1', 'ORCID', 'http://orcid.org/0000-0005-5355-5541', '0000-00-00 00:00:00', 'test.nl');
```

The `urn` should match the surfconextId of the authenticating user. When logging in with mujina this should be: `urn:collab:person:example.com:USERNAME`

For the AA service to work you might need to reprovision OpenConext-deploy

Translations have been set to values that made sense to me. As always I'm open to suggestions. See screenshots below for the current translation values.