### PR TITLE
Post read-api requests

### DIFF
--- a/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Service/AttributeReleasePolicyService.php
@@ -89,8 +89,12 @@ final class AttributeReleasePolicyService
         // Arp is applied for all entities
         $response = $this->jsonApiClient->post($data, '/arp');
 
+        $data = [
+            'entityIds'  => $entityIds,
+        ];
+
         // Arp information is retrieved for all entities with arp enabled.
-        $arpResponse = $this->jsonApiClient->read('/read-arp?entityIds=%s', [implode(',', $entityIds)]);
+        $arpResponse = $this->jsonApiClient->post($data, '/read-arp');
 
         $specifiedConsents = $consentList->map(
             function (Consent $consent) use ($response, $arpResponse) {

--- a/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
+++ b/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
@@ -144,11 +144,16 @@ class AttributeReleasePolicyServiceTest extends TestCase
             ],
         ];
 
-        $client->shouldReceive('read')
+        $client->shouldReceive('post')
             ->withArgs(
                 [
-                    '/read-arp?entityIds=%s',
-                    ['some-entity-id,another-entity-id'],
+                    [
+                        'entityIds' => [
+                            'some-entity-id',
+                            'another-entity-id',
+                        ]
+                    ],
+                    '/read-arp',
                 ]
             )
             ->andReturn($arpData);


### PR DESCRIPTION
A recent change in the EngineBlock api dictates that the read-api
 endpoint should be used using POST requests. This commit fixes that
 for Profile.

This is part of bugfix: https://www.pivotaltracker.com/story/show/155497459