### PR TITLE
Don't error when single-signon is not completed

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/config/services.yml
+++ b/src/OpenConext/ProfileBundle/Resources/config/services.yml
@@ -118,6 +118,7 @@ services:
         class: OpenConext\ProfileBundle\Security\Firewall\SamlListener
         arguments:
             - @session
+            - @router
             - @security.token_storage
             - @security.authentication.manager
             - @profile.security.authentication.saml


### PR DESCRIPTION
When a SSO action is initiated by profile but not completed by the
user, profile throws a server error on subsequent visits to profile.

This commit re-initiates the SSO action if the previous action was not
completed.

See: https://www.pivotaltracker.com/story/show/154839079