### PR TITLE
Append a cache-buster to all frontend assets

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -18,6 +18,7 @@ framework:
     validation:      { enable_annotations: true }
     templating:
         engines: ['twig']
+        assets_version: "#ASSETS_VERSION#"
     default_locale:  "%default_locale%"
     trusted_hosts:   ~
     trusted_proxies: ~

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -6,6 +6,8 @@ framework:
         resource: "%kernel.root_dir%/config/routing_dev.yml"
         strict_requirements: true
     profiler: { only_exceptions: false }
+    templating:
+        assets_version: "dev"
 
 web_profiler:
     toolbar: true

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -7,6 +7,8 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         collect: false
+    templating:
+        assets_version: "test"
 
 web_profiler:
     toolbar: false

--- a/makeRelease.sh
+++ b/makeRelease.sh
@@ -51,6 +51,9 @@ COMMITHASH=`git rev-parse HEAD` &&
 echo "Tag: ${TAG}" > ${PROJECT_DIR}/RELEASE &&
 echo "Commit: ${COMMITHASH}" >> ${PROJECT_DIR}/RELEASE &&
 
+echo "Updating asset_version in config"
+sed -i s,#ASSETS_VERSION#,${TAG},g ${PROJECT_DIR}/app/config/config.yml
+
 echo "Cleaning build of dev files" &&
 rm -rf ${PROJECT_DIR}/ansible &&
 rm -rf ${PROJECT_DIR}/Vagrantfile &&


### PR DESCRIPTION
Symfony automatically appends the cache buster using the value
configured in config.yml. This defaults to 'dev' or 'test' on those
environments, and the release tarball contains the git version of the
release.

See: https://www.pivotaltracker.com/story/show/154996487