### PR TITLE
Allow IDP metadata without contacts

### DIFF
--- a/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ContactPersonListFactoryTest.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ContactPersonListFactoryTest.php
@@ -147,4 +147,45 @@ final class ContactPersonListFactoryTest extends TestCase
 
         $this->assertEquals($expectedContactPersonList, ContactPersonListFactory::createListFromMetadata($given));
     }
+
+    /**
+     * @test
+     * @group ContactPerson
+     */
+    public function contact_person_list_without_contact_persons_can_be_deserialized()
+    {
+        $given = [
+            'contact_persons' => []
+        ];
+
+        $expectedContactPersonList = new ContactPersonList([]);
+
+        $this->assertEquals($expectedContactPersonList, ContactPersonListFactory::createListFromMetadata($given));
+    }
+
+
+    /**
+     * @test
+     * @group ContactPerson
+     */
+    public function contact_person_list_with_one_contact_person_can_be_deserialized()
+    {
+        $given = [
+            'contact_persons' => [
+                [
+                    'contact_type'  => 'other',
+                    'email_address' => 'valid@email.address.example.org',
+                ]
+            ]
+        ];
+
+        $expectedContactPersonList = new ContactPersonList([
+            new ContactPerson(
+                new ContactType(ContactType::TYPE_OTHER),
+                new ContactEmailAddress('valid@email.address.example.org')
+            ),
+        ]);
+
+        $this->assertEquals($expectedContactPersonList, ContactPersonListFactory::createListFromMetadata($given));
+    }
 }

--- a/src/OpenConext/EngineBlockApiClientBundle/Value/ContactPersonListFactory.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Value/ContactPersonListFactory.php
@@ -32,9 +32,9 @@ final class ContactPersonListFactory
      */
     public static function createListFromMetadata($data)
     {
-        Assert::isArray($data, 'Contact list JSON structure must be an associative array, got %s');
+        Assert::isArray($data, 'Metadata JSON structure must be an associative array, got %s');
         Assert::keyExists($data, 'contact_persons', 'Entity JSON structure must contain key "contact_persons"');
-        Assert::isArray($data, 'Contact persons JSON structure must be an associative array, got %s');
+        Assert::isArray($data['contact_persons'], 'Contact persons JSON structure must be an associative array, got %s');
 
         // We cannot use self::class because translation extractions fails on that
         $contactPersons = array_map(

--- a/src/OpenConext/Profile/Value/ContactPersonList.php
+++ b/src/OpenConext/Profile/Value/ContactPersonList.php
@@ -28,7 +28,7 @@ final class ContactPersonList implements IteratorAggregate, Countable
     /**
      * @var ContactPerson[]
      */
-    private $contactPersons;
+    private $contactPersons = [];
 
     public function __construct(array $contactPersons)
     {


### PR DESCRIPTION
The ContactPersonList initialized in an invalid state when created
with an empty array. It is now possible to have a list object without
contacts in it.

Another measure taken in this commit, although not required, is not
trusting EngineBlock to send an empty array in the case there are no
contacts.

Fixes #94
See: https://www.pivotaltracker.com/story/show/155390093