### PR TITLE
Add eduPersonOrcid translation to translations template

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/views/translations.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/translations.html.twig
@@ -24,6 +24,7 @@
 {{ 'profile.saml.attributes.eduPersonTargetedID'|trans({}, 'saml') }}
 {{ 'profile.saml.attributes.isMemberOf'|trans({}, 'saml') }}
 {{ 'profile.saml.attributes.eduPersonNickname'|trans({}, 'saml') }}
+{{ 'profile.saml.attributes.eduPersonOrcid'|trans({}, 'saml') }}
 {{ 'profile.saml.attributes.eduPersonOrgDN'|trans({}, 'saml') }}
 {{ 'profile.saml.attributes.eduPersonOrgUnitDN'|trans({}, 'saml') }}
 {{ 'profile.saml.attributes.eduPersonPrimaryAffiliation'|trans({}, 'saml') }}


### PR DESCRIPTION
The attribute was forgotten in commit a00d306. This makes sure a
translation scan won't delete the translation from the xliff file.