### PR TITLE
 Display the support URL on 'My Services' 

### DIFF
--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-02T15:23:24Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2018-03-02T16:12:19Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -303,12 +303,12 @@ This profile page gives you insight in which personal data, provided by your ins
       <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
         <source>profile.my_services.consent_first_used_on</source>
         <target>First used on</target>
-        <jms:reference-file line="55">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="65">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="927d4519f4715517225aa5df22bf583e6421a0cf" resname="profile.my_services.consent_type">
         <source>profile.my_services.consent_type</source>
         <target>Consent was given by</target>
-        <jms:reference-file line="45">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="55">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fc4ed9e167b467c2e26198429db9e75c2914cce6" resname="profile.my_services.error_loading_consent">
         <source>profile.my_services.error_loading_consent</source>
@@ -338,12 +338,12 @@ This profile page gives you insight in which personal data, provided by your ins
       <trans-unit id="286aef124b54c35d42540b3c44ef082c8b86b363" resname="profile.my_services.explicit_consent_given">
         <source>profile.my_services.explicit_consent_given</source>
         <target>user</target>
-        <jms:reference-file line="48">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="58">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c815c74e5f7765a5d5e5c419a59bbff5f874a5be" resname="profile.my_services.implicit_consent_given">
         <source>profile.my_services.implicit_consent_given</source>
         <target>institution</target>
-        <jms:reference-file line="50">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="60">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="107928a44903768c109c65916394c80a60c49e1e" resname="profile.my_services.long_title">
         <source>profile.my_services.long_title</source>
@@ -353,7 +353,7 @@ This profile page gives you insight in which personal data, provided by your ins
       <trans-unit id="f33a1baf8657a48868fa5624e490ca95134c5b96" resname="profile.my_services.no_attribute_released">
         <source>profile.my_services.no_attribute_released</source>
         <target>This service does not receive information about you.</target>
-        <jms:reference-file line="63">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="73">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a56f9f031cd71cad0cbf03e1a523825720214a53" resname="profile.my_services.short_title">
         <source>profile.my_services.short_title</source>
@@ -366,6 +366,11 @@ This profile page gives you insight in which personal data, provided by your ins
       <trans-unit id="22e22666c2969a24c385952a44da34ff2d808837" resname="profile.my_services.supportEmail">
         <source>profile.my_services.supportEmail</source>
         <target>Support Email</target>
+        <jms:reference-file line="47">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="1912664fc31e1686c116060dca4dac2019a2d47b" resname="profile.my_services.support_url">
+        <source>profile.my_services.support_url</source>
+        <target>Support</target>
         <jms:reference-file line="37">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="313af0cef887cdef1a6b4d5911515250d3010a25" resname="profile.my_surf_conext.account_data">

--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-11T10:01:27Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2018-03-02T15:23:24Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,506 +9,516 @@
       <trans-unit id="4422839d75319cb038791289059a5c37b6464d3e" resname="profile.application.header">
         <source>profile.application.header</source>
         <target>Overview of your SURFconext profile</target>
-        <jms:reference-file line="20">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c01fb1e47571e92614557108db2ebb516dcdb7c0" resname="profile.application.platform_connection_description">
         <source>profile.application.platform_connection_description</source>
         <target>This is a service connected through</target>
-        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="71">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="18e70a3e75cc5e9f61e4a379a265ae1bcdb71148" resname="profile.application.platform_connection_name">
         <source>profile.application.platform_connection_name</source>
         <target>SURFconext</target>
-        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="71">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d25aa7a2e9d40a5e7039dd3b93bd91eea40251c5" resname="profile.application.title">
         <source>profile.application.title</source>
         <target>SURFconext Profile</target>
-        <jms:reference-file line="6">/Resources/views/base.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../../../../../app/Resources/views/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ececc3f56e8ad293cd7ac9811787ef3bd0bc6041" resname="profile.attribute_support.explanation">
         <source>profile.attribute_support.explanation</source>
         <target>SURFconext support may ask you to share the abovementioned data. This information can help them to answer your support question.</target>
-        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0c6975044e5b9e02815772e60105ae78a4743c22" resname="profile.attribute_support.long_title">
         <source>profile.attribute_support.long_title</source>
         <target>Send data to SURFconext support</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="357ac936f886f677a14e8401fb48af23827d513d" resname="profile.attribute_support.send_mail">
         <source>profile.attribute_support.send_mail</source>
         <target>Send data</target>
-        <jms:reference-file line="34">/../src/OpenConext/ProfileBundle/Form/Type/AttributeSupportMailType.php</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../src/OpenConext/ProfileBundle/Form/Type/AttributeSupportMailType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a12580758185add38d70d00e359e0d4cb2463a0d" resname="profile.attribute_support.short_title">
         <source>profile.attribute_support.short_title</source>
         <target>Send data</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7155ef337fbeb3cf5d5066d4d35fc435a1f73394" resname="profile.attribute_support_confirmation.explanation">
         <source>profile.attribute_support_confirmation.explanation</source>
         <target xml:space="preserve">The mail with your information has been successfully sent.
 </target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="73c60b3f75233586e48a1c7de310940633a523e0" resname="profile.attribute_support_confirmation.long_title">
         <source>profile.attribute_support_confirmation.long_title</source>
         <target>Attribute data has been mailed</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="53d04262f1ab47280551fae7076d7793629fa379" resname="profile.attribute_support_confirmation.short_title">
         <source>profile.attribute_support_confirmation.short_title</source>
         <target>Attribute data mailed</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2e799f3107a8bb43962025dfc3883e9b7ac96d41" resname="profile.confirm_connection_delete.confirm">
         <source>profile.confirm_connection_delete.confirm</source>
         <target>Confirm</target>
-        <jms:reference-file line="50">/../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
+        <jms:reference-file line="50">/../../../../../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="757f129ed6459928baf538b9c6947626808aee49" resname="profile.confirm_connection_delete.confirm_label">
         <source>profile.confirm_connection_delete.confirm_label</source>
         <target>I agree to disconnect this connection.</target>
-        <jms:reference-file line="42">/../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="635d3df5bf4d25f2ba2aa31d49a7b66a18a78d59" resname="profile.information_request.explanation">
         <source>profile.information_request.explanation</source>
         <target>If you press 'confirm request', your attributes will be sent to the Privacy Officer of SURFnet, and your request about the processing of personal data will be taken care of.</target>
-        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="89472af12a7436b02c77eeffe6e86a583c4536a0" resname="profile.information_request.long_title">
         <source>profile.information_request.long_title</source>
         <target>Identification because of request data subject</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f067c475cbd61e820226d34409c92ecf1d184765" resname="profile.information_request.send_mail">
         <source>profile.information_request.send_mail</source>
         <target>Confirm request</target>
-        <jms:reference-file line="33">/../src/OpenConext/ProfileBundle/Form/Type/InformationRequestMailType.php</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../src/OpenConext/ProfileBundle/Form/Type/InformationRequestMailType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e4e38a5280ad5872ca42364782d403241b69ebc" resname="profile.information_request.short_title">
         <source>profile.information_request.short_title</source>
         <target>Identification request</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0b56f33c8b70e279ed12dcab82025850b1aa5cf4" resname="profile.information_request_confirmation.explanation">
         <source>profile.information_request_confirmation.explanation</source>
         <target>Your request about the processing of personal data will be taken care of.</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="418a8fb888fab781f0a609bdfd4df923ecb2d6d0" resname="profile.information_request_confirmation.long_title">
         <source>profile.information_request_confirmation.long_title</source>
         <target>Thanks for sending your attributes</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77b1f830cef4a3d830b74360ea04e9689ff664b8" resname="profile.information_request_confirmation.short_title">
         <source>profile.information_request_confirmation.short_title</source>
         <target>Identification request</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d8ab8fc21a0850ff35b514cb473d58cb46ff512" resname="profile.introduction.explanation.introduction">
         <source>profile.introduction.explanation.introduction</source>
         <target>Your institution uses SURFconext to allow you to login to several online (cloud)services using your institutional account. Instead of registering separate accounts for each service, this means you only need a single account to login. The following picture gives a schematic overview of what SURFconext does:</target>
-        <jms:reference-file line="11">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4949b24da6847ff0e5ab5ba5ec14a85eb5da703e" resname="profile.introduction.explanation.title">
         <source>profile.introduction.explanation.title</source>
         <target>What is SURFconext?</target>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a58594e3e7d64ad7c5ee1852e90242f76476563" resname="profile.introduction.long_title">
         <source>profile.introduction.long_title</source>
         <target>The SURFconext Profile page</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b5046cf89bbccbd70597521e4f435425bb6745a5" resname="profile.introduction.purpose.profile_storage">
         <source>profile.introduction.purpose.profile_storage</source>
         <target xml:space="preserve">On behalf of your institution, SURFconext forwards a limited amount of your personal data to the service you are logging in to. Most of the times you are required to give explicit consent for this information transfer. In some cases, however, this feature is disabled on request of your institution.
 
 This profile page gives you insight in which personal data, provided by your institution via SURFconext, has been forwarded to which service. You can also review which personal data is being stored by SURFconext and which services you have logged in to in the past.</target>
-        <jms:reference-file line="16">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2cd8741e2e784f6e2df5165585c332d6be98812c" resname="profile.introduction.purpose.title">
         <source>profile.introduction.purpose.title</source>
         <target>What is the purpose of this profile page?</target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3bc6272408dd954ac55ea238358d3603526cfefb" resname="profile.introduction.short_title">
         <source>profile.introduction.short_title</source>
         <target>Introduction</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="5">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f554f3775d3630e1d20047b07d2b2e7735f58970" resname="profile.locale.choose_locale">
         <source>profile.locale.choose_locale</source>
         <target>Choose language</target>
-        <jms:reference-file line="73">/../src/OpenConext/ProfileBundle/Form/Type/SwitchLocaleType.php</jms:reference-file>
+        <jms:reference-file line="73">/../../../../../src/OpenConext/ProfileBundle/Form/Type/SwitchLocaleType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0135c23e335a69b86430fa515b01d20cb65a21c4" resname="profile.locale.en">
         <source>profile.locale.en</source>
         <target>EN</target>
-        <jms:reference-file line="168">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="168">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6f6d681a481879428f3cb1fedecc96d9774eecbb" resname="profile.locale.locale_change_fail">
         <source>profile.locale.locale_change_fail</source>
         <target>Could not change language</target>
-        <jms:reference-file line="172">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="172">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7b6a058e52a45bcdc469105f7313e05eb39ad69b" resname="profile.locale.locale_change_success">
         <source>profile.locale.locale_change_success</source>
         <target>Language changed</target>
-        <jms:reference-file line="171">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="171">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e2fbaef81b77d24930074533408e4d9fd514dcd2" resname="profile.locale.nl">
         <source>profile.locale.nl</source>
         <target>NL</target>
-        <jms:reference-file line="169">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="169">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9efb18562f68975294c34a9d578af71915151cc5" resname="profile.my_connections.active_connections">
         <source>profile.my_connections.active_connections</source>
         <target>Active connections</target>
-        <jms:reference-file line="18">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b45e0cbe033a9a0c1c9ca4f86be6bfe4c30f7681" resname="profile.my_connections.available_connections">
         <source>profile.my_connections.available_connections</source>
         <target>Available Connections</target>
-        <jms:reference-file line="56">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="56">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5786ea6a363e616a432c6c437314c328dbdca83c" resname="profile.my_connections.description_label">
         <source>profile.my_connections.description_label</source>
         <target>Description</target>
-        <jms:reference-file line="70">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="70">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dabc34079097e6ea7a29934f274e65a91e95f82a" resname="profile.my_connections.explanation">
         <source>profile.my_connections.explanation</source>
         <target>It's possible to connect external sources to your SURFconext profile. SURFconext can use this information to enrich the existing attributes of your institutional account with the values from this external account. Services connected to SURFconext can receive and use this information.</target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="287927bbc9031325f1d5a3efeb26577352fe68f9" resname="profile.my_connections.long_title">
         <source>profile.my_connections.long_title</source>
         <target>Accounts linked to your profile</target>
-        <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="34ce48e722c206f299190088acea1e55ba420e99" resname="profile.my_connections.missing_connections">
         <source>profile.my_connections.missing_connections</source>
         <target>Missing Connections?</target>
-        <jms:reference-file line="86">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="85">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d8030c905e3901505ffa45585843d95d71cedb7a" resname="profile.my_connections.no_active_connections.description">
         <source>profile.my_connections.no_active_connections.description</source>
         <target>You don't have any active connections yet.</target>
-        <jms:reference-file line="20">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ec33c82bf179989652928e2df38fcf975c378d95" resname="profile.my_connections.no_connections_configured.description">
         <source>profile.my_connections.no_connections_configured.description</source>
         <target>At the moment there are no connections that are available for configuration.</target>
-        <jms:reference-file line="58">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="58">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d1a92495d8e08cf89bf517af5ffe5461407d2921" resname="profile.my_connections.orcid.connect_title">
         <source>profile.my_connections.orcid.connect_title</source>
         <target>Connect</target>
-        <jms:reference-file line="78">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="77">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c4b69512880a8532d9740e870ed8a60b8791b3bc" resname="profile.my_connections.orcid.description">
         <source>profile.my_connections.orcid.description</source>
         <target>ORCID is a nonproprietary alphanumeric code to uniquely identify scientific and other academic authors. This addresses the problem that a particular author's contributions to the scientific literature or publications in the humanities can be hard to recognize as most personal names are not unique, they can change (such as with marriage), have cultural differences in name order, contain inconsistent use of first-name abbreviations and employ different writing systems.</target>
-        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="71">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4bc8f1ebcd9026ebbc6df9e128e3a1c0d4407ebd" resname="profile.my_connections.orcid.disconnect_title">
         <source>profile.my_connections.orcid.disconnect_title</source>
         <target>Disconnect</target>
-        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bd50bc94d1957cd597c43c9a1eb6284461d48482" resname="profile.my_connections.orcid.status">
         <source>profile.my_connections.orcid.status</source>
         <target>Status</target>
-        <jms:reference-file line="34">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f36591d6cd52fa2b3b097b9cd4ca900700fe22e" resname="profile.my_connections.orcid.status_connected">
         <source>profile.my_connections.orcid.status_connected</source>
         <target>Connected</target>
-        <jms:reference-file line="35">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb0b77c5fd95698ab75dbd35962d63c0e76e9f2c" resname="profile.my_connections.orcid.title">
         <source>profile.my_connections.orcid.title</source>
         <target>ORCID</target>
-        <jms:reference-file line="27">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="30">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="67">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="27">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="67">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d8ba5b858f788ea3b20782b6d6a2653ab34581c" resname="profile.my_connections.send_request">
         <source>profile.my_connections.send_request</source>
         <target>Send us a request</target>
-        <jms:reference-file line="87">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="86">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d19d7e654594f5a24af2d7ccd23a3678082a0db4" resname="profile.my_connections.service_label">
         <source>profile.my_connections.service_label</source>
         <target>Service</target>
-        <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="66">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="66">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f61fad44caa0beb389084eb69cd3663855a1a3ac" resname="profile.my_connections.short_title">
         <source>profile.my_connections.short_title</source>
         <target>My Connections</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b172b6b32cc00171f63b2834d2710be9a0e882fd" resname="profile.my_profile.attributes_information_link_title">
         <source>profile.my_profile.attributes_information_link_title</source>
         <target>Attributes in SURFconext</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="802fbec3f5be7a9a00873faea70d1513155e09c2" resname="profile.my_profile.introduction">
         <source>profile.my_profile.introduction</source>
         <target>The table below contains an overview of all your personal data that your institution can pass on to several services through SURFconext. Within SURFconext, your personal data are called 'attributes'. An attribute can for instance be your name, your e-mail address or the name of your institution. For more technical information about these attributes, SURFconext provides the following extra information page:</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="009b61d8df294d85f3271d872de139c7188473e2" resname="profile.my_profile.long_title">
         <source>profile.my_profile.long_title</source>
         <target>Information from your institution</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a889019ee05f5be48abcfacba0b63235275ce299" resname="profile.my_profile.pi_processing">
         <source>profile.my_profile.pi_processing</source>
         <target>On the tab "My SURFconext" you can see which attributes and data is being stored by SURFconext itself.</target>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc93ed7bab761ec4c240fa28983bc1f069328991" resname="profile.my_profile.questions">
         <source>profile.my_profile.questions</source>
         <target>Please note: your institution is responsible for the personal data displayed here. SURFconext is simply showing the information received from your institution. If you have any questions about your attributes, please contact the help desk of your institution through:</target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c35bcd376a8ad4ea3b6e7c4a297f3f8622d6927e" resname="profile.my_profile.questions_no_support_contact_email">
         <source>profile.my_profile.questions_no_support_contact_email</source>
         <target>If you have any questions about your personal data, please contact the help desk of your institution.</target>
-        <jms:reference-file line="17">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f1e5e770356348259bcc4b16b55b4fbf30fdeed1" resname="profile.my_profile.short_title">
         <source>profile.my_profile.short_title</source>
         <target>My Profile</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="41aded5ca8217152487f685b47f640799d76e24f" resname="profile.my_services.attribute_release_description">
         <source>profile.my_services.attribute_release_description</source>
         <target>This service receives the following information about you:</target>
-        <jms:reference-file line="1">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="1">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="069a217bbb82a2da6a0c01cb25256919a35b62af" resname="profile.my_services.attribute_release_description_with_source">
         <source>profile.my_services.attribute_release_description_with_source</source>
         <target>This service receives the following information about you from %source%:</target>
-        <jms:reference-file line="1">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
+        <jms:reference-file line="1">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
         <source>profile.my_services.consent_first_used_on</source>
         <target>First used on</target>
-        <jms:reference-file line="55">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="55">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="927d4519f4715517225aa5df22bf583e6421a0cf" resname="profile.my_services.consent_type">
         <source>profile.my_services.consent_type</source>
         <target>Consent was given by</target>
-        <jms:reference-file line="45">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="45">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fc4ed9e167b467c2e26198429db9e75c2914cce6" resname="profile.my_services.error_loading_consent">
         <source>profile.my_services.error_loading_consent</source>
         <target>The list of services which you are logged in to cannot be retrieved.</target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4fe6e0fef0fda46518eed058ae7a8411633d205d" resname="profile.my_services.eula">
         <source>profile.my_services.eula</source>
         <target>EULA</target>
-        <jms:reference-file line="29">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="29">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e792a9988ccfee30143187c270b5e0dffc59020c" resname="profile.my_services.explanation">
         <source>profile.my_services.explanation</source>
         <target>This overview contains all services you have logged in to through SURFconext at least once. It also shows which subset of your personal data (attributes) has been shared between your institution and the service. Additionally, you can see whether you or your institutiton has agreed to sharing your attributes with the service:</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a92f83f99644130d2de961b6add4752a8ed6c3cc" resname="profile.my_services.explanation.explicit_consent">
         <source>profile.my_services.explanation.explicit_consent</source>
         <target>Consent by you: some services explicitly require you to consent to forwarding personal data the first time you login.</target>
-        <jms:reference-file line="11">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1903f16c642b35604024fbd11029cb099d14bb6e" resname="profile.my_services.explanation.implicit_consent">
         <source>profile.my_services.explanation.implicit_consent</source>
         <target>Consent by institution: some services do not explicitly require you to consent to forwarding personal data, because your institution already arranged for this. The information is shared automatically after logging in.</target>
-        <jms:reference-file line="12">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="286aef124b54c35d42540b3c44ef082c8b86b363" resname="profile.my_services.explicit_consent_given">
         <source>profile.my_services.explicit_consent_given</source>
         <target>user</target>
-        <jms:reference-file line="48">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="48">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c815c74e5f7765a5d5e5c419a59bbff5f874a5be" resname="profile.my_services.implicit_consent_given">
         <source>profile.my_services.implicit_consent_given</source>
         <target>institution</target>
-        <jms:reference-file line="50">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="50">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="107928a44903768c109c65916394c80a60c49e1e" resname="profile.my_services.long_title">
         <source>profile.my_services.long_title</source>
         <target>Services accessed through SURFconext</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f33a1baf8657a48868fa5624e490ca95134c5b96" resname="profile.my_services.no_attribute_released">
         <source>profile.my_services.no_attribute_released</source>
         <target>This service does not receive information about you.</target>
-        <jms:reference-file line="63">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="63">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a56f9f031cd71cad0cbf03e1a523825720214a53" resname="profile.my_services.short_title">
         <source>profile.my_services.short_title</source>
         <target>My Services</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="47">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="22e22666c2969a24c385952a44da34ff2d808837" resname="profile.my_services.supportEmail">
         <source>profile.my_services.supportEmail</source>
         <target>Support Email</target>
-        <jms:reference-file line="37">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="313af0cef887cdef1a6b4d5911515250d3010a25" resname="profile.my_surf_conext.account_data">
         <source>profile.my_surf_conext.account_data</source>
         <target>Account data</target>
-        <jms:reference-file line="12">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="88d5aa8d809e37e148138cabeb06a1f851d41ed0" resname="profile.my_surf_conext.account_data_explanation">
         <source>profile.my_surf_conext.account_data_explanation</source>
         <target>SURFconext can provide (cloud) services a privacy-friendly identifier (number) with which you can be recognized when you return to the service.</target>
-        <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2cceeab9b6a5ca79fdd2d506853f5292e1afb872" resname="profile.my_surf_conext.account_data_origin">
         <source>profile.my_surf_conext.account_data_origin</source>
         <target>User ID and institution name from your institution + number generated by SURFconext</target>
-        <jms:reference-file line="19">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="19">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="85dde9b709fc5f0684d02cec3d797f669f3dd001" resname="profile.my_surf_conext.account_data_retention_period">
         <source>profile.my_surf_conext.account_data_retention_period</source>
         <target>Until 3 years after first login.</target>
-        <jms:reference-file line="23">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="23">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="be73e1bc34923830cbb8c48bfc1697af4b1a827a" resname="profile.my_surf_conext.consent_data">
         <source>profile.my_surf_conext.consent_data</source>
         <target>Consent Data</target>
-        <jms:reference-file line="46">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="46">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a4a1d52b47f79dbd7e6c21302010b061e897565" resname="profile.my_surf_conext.consent_data_explanation">
         <source>profile.my_surf_conext.consent_data_explanation</source>
         <target>Most services require you, prior to the first login, to explicitly give consent to your institution to share your personal data with the service you are logging in to. SURFconext stores at which moment and for which service you have given consent. To see which personal data is being shared with which service, please go to</target>
-        <jms:reference-file line="47">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="972f4bcdbdd3c6aa6acabcbac0942c53cf33b6e8" resname="profile.my_surf_conext.consent_data_origin">
         <source>profile.my_surf_conext.consent_data_origin</source>
         <target>Generated by SURFconext</target>
-        <jms:reference-file line="53">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="53">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fadb692e51d3071903f8e51749e57a5b989c8ecc" resname="profile.my_surf_conext.consent_data_retention_period">
         <source>profile.my_surf_conext.consent_data_retention_period</source>
         <target>Until 3 years after last login.</target>
-        <jms:reference-file line="57">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="57">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="602265c6c69cb0a3e3ba202914cb1efc16e95f1c" resname="profile.my_surf_conext.data_origin">
         <source>profile.my_surf_conext.data_origin</source>
         <target>Information and origin</target>
-        <jms:reference-file line="18">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5169f77f250fabf4445380d02e986b37f9ad10d7" resname="profile.my_surf_conext.data_retention_period">
         <source>profile.my_surf_conext.data_retention_period</source>
         <target>Retention Period</target>
-        <jms:reference-file line="22">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="39">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="56">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="56">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37d164bfb27988f8a5a5e4882401b8df2142740d" resname="profile.my_surf_conext.introduction">
         <source>profile.my_surf_conext.introduction</source>
         <target>SURFconext stores certain data to allow you to log in easily and securely to various (cloud) services and to give you insight into which services you have logged in to through SURFconext. Your institution decides which services are accessible for you through SURFconext. Most services you use through SURFconext request a subset of this data. Some services require no personal data. If you want to see which services received which data, please refer to %my_services_link%.</target>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="198dce1e77b95dfaa8e56ec5ba8f44a46bf69215" resname="profile.my_surf_conext.logging_data">
         <source>profile.my_surf_conext.logging_data</source>
         <target>Logging Data</target>
-        <jms:reference-file line="29">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="29">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9d699ca9640ad2fe880c19c29007cbe30dd3d378" resname="profile.my_surf_conext.logging_data_explanation">
         <source>profile.my_surf_conext.logging_data_explanation</source>
         <target>SURFconext logs when you use SURFconext, which service you are logging in to and from which IP address. This is necessary for administration and security purposes.</target>
-        <jms:reference-file line="30">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eaf93e5a9f8e999a138ecfb99ce5e7ff95bb7f86" resname="profile.my_surf_conext.logging_data_origin">
         <source>profile.my_surf_conext.logging_data_origin</source>
         <target>Generated by SURFconext</target>
-        <jms:reference-file line="36">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="caddd61ed1171bbd0b0f996b78c6fcbbcffc356a" resname="profile.my_surf_conext.logging_data_retention_period">
         <source>profile.my_surf_conext.logging_data_retention_period</source>
         <target>6 months. After 6 months the log files are anonymized.</target>
-        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="128b376e6b372c962506ec6b3bd7ba92a69f71f1" resname="profile.my_surf_conext.long_title">
         <source>profile.my_surf_conext.long_title</source>
         <target>Details of your SURFconext profile</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="90932e1aff99c6f99c5807eec180c40db5a32485" resname="profile.my_surf_conext.origin">
         <source>profile.my_surf_conext.origin</source>
         <target>Origin</target>
-        <jms:reference-file line="35">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="52">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="52">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="010ed9d837beee859a1f028bf9748f9ab7b31a4e" resname="profile.my_surf_conext.short_title">
         <source>profile.my_surf_conext.short_title</source>
         <target>My SURFconext</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="21">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc8455ffe1c5bde28802e8445e31e3d1f5c12a7a" resname="profile.navigation.help">
         <source>profile.navigation.help</source>
         <target>Help</target>
-        <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
-        <jms:reference-file line="79">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="79">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="73f3979adec1e8f8b69cd5b18c0bdad323cde224" resname="profile.navigation.terms_of_service">
         <source>profile.navigation.terms_of_service</source>
         <target>Terms of Service</target>
-        <jms:reference-file line="82">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="82">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="f5d0957a4421ee6ecaf81e9c8a568650a015770a" resname="profile.saml.attributes.eduPersonTargetedId.persistent">
+        <source>profile.saml.attributes.eduPersonTargetedId.persistent</source>
+        <target>Pseudonym that differs for each service</target>
+        <jms:reference-file line="34">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="6dfc05705bd5f8f27a26d62e7826aebaeecd4d15" resname="profile.saml.attributes.eduPersonTargetedId.transient">
+        <source>profile.saml.attributes.eduPersonTargetedId.transient</source>
+        <target>Pseudonym that changes with every login</target>
+        <jms:reference-file line="32">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3c4f154ed62c838e29dc22974f574af5cb2b2f8e" resname="profile.table.attribute_name">
         <source>profile.table.attribute_name</source>
         <target>Attribute</target>
-        <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="24">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="6">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
-        <jms:reference-file line="6">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="24">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="547ea301afc0bae2bdbdedec6915fa51c654ff52" resname="profile.table.attribute_value">
         <source>profile.table.attribute_value</source>
         <target>Value</target>
-        <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="25">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0116d16056d9cd75bfe4bf170b5b504d8b939a38" resname="profile.table.source_description.orcid">
         <source>profile.table.source_description.orcid</source>
         <target>ORCID iD</target>
-        <jms:reference-file line="175">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="175">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e591d4c6d94037cb4aca3294d989e63eeb15663f" resname="profile.table.source_description.sab">
         <source>profile.table.source_description.sab</source>
         <target>SURFnet Autorisatie Beheer</target>
-        <jms:reference-file line="176">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="176">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="7eaa211c78eb7290993519c729e4e05c49269da3" resname="profile.table.source_description.surfmarket_entitlements">
+      <trans-unit id="98a7e142496864319f0b2c6b931da715b4e000db" resname="profile.table.source_description.surfmarket_entitlements">
         <source>profile.table.source_description.surfmarket_entitlements</source>
         <target>SURFmarket Entitlements</target>
-        <jms:reference-file line="177">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="177">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4b1c5ddcfd432d3477264f068b21ff7996915e06" resname="profile.table.source_description.voot">
         <source>profile.table.source_description.voot</source>
         <target>Group membership</target>
-        <jms:reference-file line="174">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="174">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/messages.nl.xliff
+++ b/app/Resources/translations/messages.nl.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-02T15:23:26Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
+  <file date="2018-03-02T16:12:24Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -303,12 +303,12 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
       <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
         <source>profile.my_services.consent_first_used_on</source>
         <target>Voor het eerst gebruikt op</target>
-        <jms:reference-file line="55">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="65">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="927d4519f4715517225aa5df22bf583e6421a0cf" resname="profile.my_services.consent_type">
         <source>profile.my_services.consent_type</source>
         <target>Toestemming gegeven door</target>
-        <jms:reference-file line="45">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="55">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fc4ed9e167b467c2e26198429db9e75c2914cce6" resname="profile.my_services.error_loading_consent">
         <source>profile.my_services.error_loading_consent</source>
@@ -338,12 +338,12 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
       <trans-unit id="286aef124b54c35d42540b3c44ef082c8b86b363" resname="profile.my_services.explicit_consent_given">
         <source>profile.my_services.explicit_consent_given</source>
         <target>gebruiker</target>
-        <jms:reference-file line="48">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="58">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c815c74e5f7765a5d5e5c419a59bbff5f874a5be" resname="profile.my_services.implicit_consent_given">
         <source>profile.my_services.implicit_consent_given</source>
         <target>instelling</target>
-        <jms:reference-file line="50">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="60">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="107928a44903768c109c65916394c80a60c49e1e" resname="profile.my_services.long_title">
         <source>profile.my_services.long_title</source>
@@ -353,7 +353,7 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
       <trans-unit id="f33a1baf8657a48868fa5624e490ca95134c5b96" resname="profile.my_services.no_attribute_released">
         <source>profile.my_services.no_attribute_released</source>
         <target>Deze dienst ontvangt geen gegevens over jou.</target>
-        <jms:reference-file line="63">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="73">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a56f9f031cd71cad0cbf03e1a523825720214a53" resname="profile.my_services.short_title">
         <source>profile.my_services.short_title</source>
@@ -366,6 +366,11 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
       <trans-unit id="22e22666c2969a24c385952a44da34ff2d808837" resname="profile.my_services.supportEmail">
         <source>profile.my_services.supportEmail</source>
         <target>E-mailadres support</target>
+        <jms:reference-file line="47">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="1912664fc31e1686c116060dca4dac2019a2d47b" resname="profile.my_services.support_url">
+        <source>profile.my_services.support_url</source>
+        <target>Support</target>
         <jms:reference-file line="37">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="313af0cef887cdef1a6b4d5911515250d3010a25" resname="profile.my_surf_conext.account_data">

--- a/app/Resources/translations/messages.nl.xliff
+++ b/app/Resources/translations/messages.nl.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-01-11T10:01:28Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
+  <file date="2018-03-02T15:23:26Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,506 +9,516 @@
       <trans-unit id="4422839d75319cb038791289059a5c37b6464d3e" resname="profile.application.header">
         <source>profile.application.header</source>
         <target>Overzicht van jouw SURFconext-profiel</target>
-        <jms:reference-file line="20">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c01fb1e47571e92614557108db2ebb516dcdb7c0" resname="profile.application.platform_connection_description">
         <source>profile.application.platform_connection_description</source>
         <target>Deze dienst is verbonden via</target>
-        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="71">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="18e70a3e75cc5e9f61e4a379a265ae1bcdb71148" resname="profile.application.platform_connection_name">
         <source>profile.application.platform_connection_name</source>
         <target>SURFconext</target>
-        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="71">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d25aa7a2e9d40a5e7039dd3b93bd91eea40251c5" resname="profile.application.title">
         <source>profile.application.title</source>
         <target>SURFconext Profile</target>
-        <jms:reference-file line="6">/Resources/views/base.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../../../../../app/Resources/views/base.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ececc3f56e8ad293cd7ac9811787ef3bd0bc6041" resname="profile.attribute_support.explanation">
         <source>profile.attribute_support.explanation</source>
         <target>SURFconext support kan je vragen om bovenstaande informatie te delen. Deze informatie kan hen helpen om jouw supportvraag te beantwoorden.</target>
-        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0c6975044e5b9e02815772e60105ae78a4743c22" resname="profile.attribute_support.long_title">
         <source>profile.attribute_support.long_title</source>
         <target>Mail data naar SURFconext support</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="357ac936f886f677a14e8401fb48af23827d513d" resname="profile.attribute_support.send_mail">
         <source>profile.attribute_support.send_mail</source>
         <target>Mail data</target>
-        <jms:reference-file line="34">/../src/OpenConext/ProfileBundle/Form/Type/AttributeSupportMailType.php</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../src/OpenConext/ProfileBundle/Form/Type/AttributeSupportMailType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a12580758185add38d70d00e359e0d4cb2463a0d" resname="profile.attribute_support.short_title">
         <source>profile.attribute_support.short_title</source>
         <target>Mail data</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7155ef337fbeb3cf5d5066d4d35fc435a1f73394" resname="profile.attribute_support_confirmation.explanation">
         <source>profile.attribute_support_confirmation.explanation</source>
         <target>De mail met informatie is succesvol verstuurd.</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="73c60b3f75233586e48a1c7de310940633a523e0" resname="profile.attribute_support_confirmation.long_title">
         <source>profile.attribute_support_confirmation.long_title</source>
         <target>De attribuutdata is gemaild</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="53d04262f1ab47280551fae7076d7793629fa379" resname="profile.attribute_support_confirmation.short_title">
         <source>profile.attribute_support_confirmation.short_title</source>
         <target>Attribuutdata gemaild</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2e799f3107a8bb43962025dfc3883e9b7ac96d41" resname="profile.confirm_connection_delete.confirm">
         <source>profile.confirm_connection_delete.confirm</source>
         <target>Toepassen</target>
-        <jms:reference-file line="50">/../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
+        <jms:reference-file line="50">/../../../../../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="757f129ed6459928baf538b9c6947626808aee49" resname="profile.confirm_connection_delete.confirm_label">
         <source>profile.confirm_connection_delete.confirm_label</source>
         <target>Ja, verwijder deze koppeling</target>
-        <jms:reference-file line="42">/../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="635d3df5bf4d25f2ba2aa31d49a7b66a18a78d59" resname="profile.information_request.explanation">
         <source>profile.information_request.explanation</source>
         <target>Door op de verzend-knop te drukken, worden uw attributen naar de Privacy Officer van SURFnet gestuurd en kan uw verzoek rondom de verwerking van persoonsgegevens in behandeling worden genomen.</target>
-        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="89472af12a7436b02c77eeffe6e86a583c4536a0" resname="profile.information_request.long_title">
         <source>profile.information_request.long_title</source>
         <target>Identificatie n.a.v. verzoek betrokkene</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f067c475cbd61e820226d34409c92ecf1d184765" resname="profile.information_request.send_mail">
         <source>profile.information_request.send_mail</source>
         <target>Verzenden</target>
-        <jms:reference-file line="33">/../src/OpenConext/ProfileBundle/Form/Type/InformationRequestMailType.php</jms:reference-file>
+        <jms:reference-file line="33">/../../../../../src/OpenConext/ProfileBundle/Form/Type/InformationRequestMailType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e4e38a5280ad5872ca42364782d403241b69ebc" resname="profile.information_request.short_title">
         <source>profile.information_request.short_title</source>
         <target>Identificatieverzoek</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0b56f33c8b70e279ed12dcab82025850b1aa5cf4" resname="profile.information_request_confirmation.explanation">
         <source>profile.information_request_confirmation.explanation</source>
         <target>Uw verzoek rondom de verwerking van persoonsgegevens zal in behandeling worden genomen.</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="418a8fb888fab781f0a609bdfd4df923ecb2d6d0" resname="profile.information_request_confirmation.long_title">
         <source>profile.information_request_confirmation.long_title</source>
         <target>Bedankt voor het verzenden van uw attributen</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77b1f830cef4a3d830b74360ea04e9689ff664b8" resname="profile.information_request_confirmation.short_title">
         <source>profile.information_request_confirmation.short_title</source>
         <target>Identificatieverzoek</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/confirmation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d8ab8fc21a0850ff35b514cb473d58cb46ff512" resname="profile.introduction.explanation.introduction">
         <source>profile.introduction.explanation.introduction</source>
         <target>Jouw instelling gebruikt SURFconext zodat je met jouw instellingsaccount kunt inloggen op verschillende (cloud)diensten. Zo heb je maar één inlogaccount nodig en hoef je niet overal een apart gebruikersaccount aan te maken. Het volgende plaatje toont een schematische weergave van wat SURFconext doet:</target>
-        <jms:reference-file line="11">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4949b24da6847ff0e5ab5ba5ec14a85eb5da703e" resname="profile.introduction.explanation.title">
         <source>profile.introduction.explanation.title</source>
         <target>Wat is SURFconext?</target>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a58594e3e7d64ad7c5ee1852e90242f76476563" resname="profile.introduction.long_title">
         <source>profile.introduction.long_title</source>
         <target>De profielpagina van SURFconext</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b5046cf89bbccbd70597521e4f435425bb6745a5" resname="profile.introduction.purpose.profile_storage">
         <source>profile.introduction.purpose.profile_storage</source>
         <target xml:space="preserve">Op verzoek van jouw instelling geeft SURFconext een beperkt aantal persoonsgegevens door aan de dienst waar je inlogt. Soms gaat dit automatisch bij het inloggen, in andere gevallen moet jij vooraf expliciet toestemming geven voor de doorgave van jouw gegevens.
 
 Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jouw instelling, via SURFconext aan welke dienst wordt doorgegeven. Ook kun je zien welke gegevens door SURFconext worden opgeslagen en bij welke diensten je in het verleden bent ingelogd via SURFconext.</target>
-        <jms:reference-file line="16">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="16">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2cd8741e2e784f6e2df5165585c332d6be98812c" resname="profile.introduction.purpose.title">
         <source>profile.introduction.purpose.title</source>
         <target xml:space="preserve">Wat kun je op deze profielpagina?
 </target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3bc6272408dd954ac55ea238358d3603526cfefb" resname="profile.introduction.short_title">
         <source>profile.introduction.short_title</source>
         <target>Introductie</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="5">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f554f3775d3630e1d20047b07d2b2e7735f58970" resname="profile.locale.choose_locale">
         <source>profile.locale.choose_locale</source>
         <target>Kies taal</target>
-        <jms:reference-file line="73">/../src/OpenConext/ProfileBundle/Form/Type/SwitchLocaleType.php</jms:reference-file>
+        <jms:reference-file line="73">/../../../../../src/OpenConext/ProfileBundle/Form/Type/SwitchLocaleType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0135c23e335a69b86430fa515b01d20cb65a21c4" resname="profile.locale.en">
         <source>profile.locale.en</source>
         <target>EN</target>
-        <jms:reference-file line="168">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="168">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6f6d681a481879428f3cb1fedecc96d9774eecbb" resname="profile.locale.locale_change_fail">
         <source>profile.locale.locale_change_fail</source>
         <target>Kon taal niet veranderen</target>
-        <jms:reference-file line="172">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="172">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7b6a058e52a45bcdc469105f7313e05eb39ad69b" resname="profile.locale.locale_change_success">
         <source>profile.locale.locale_change_success</source>
         <target>Taal veranderd</target>
-        <jms:reference-file line="171">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="171">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e2fbaef81b77d24930074533408e4d9fd514dcd2" resname="profile.locale.nl">
         <source>profile.locale.nl</source>
         <target>NL</target>
-        <jms:reference-file line="169">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="169">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9efb18562f68975294c34a9d578af71915151cc5" resname="profile.my_connections.active_connections">
         <source>profile.my_connections.active_connections</source>
         <target>Actieve koppelingen</target>
-        <jms:reference-file line="18">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b45e0cbe033a9a0c1c9ca4f86be6bfe4c30f7681" resname="profile.my_connections.available_connections">
         <source>profile.my_connections.available_connections</source>
         <target>Beschikbare koppelingen</target>
-        <jms:reference-file line="56">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="56">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5786ea6a363e616a432c6c437314c328dbdca83c" resname="profile.my_connections.description_label">
         <source>profile.my_connections.description_label</source>
         <target>Omschrijving</target>
-        <jms:reference-file line="70">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="70">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dabc34079097e6ea7a29934f274e65a91e95f82a" resname="profile.my_connections.explanation">
         <source>profile.my_connections.explanation</source>
         <target>Je kunt externe bronnen koppelen aan je SURFconext-profiel. SURFconext kan deze gegevens gebruiken om je bestaande attributen afkomstig van je instellingsaccount te verrijken met de waarden uit het gekoppelde account. Diensten die verbonden zijn met SURFconext kunnen vervolgens deze informatie ontvangen.</target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="287927bbc9031325f1d5a3efeb26577352fe68f9" resname="profile.my_connections.long_title">
         <source>profile.my_connections.long_title</source>
         <target>Accounts gelinkt aan je profiel</target>
-        <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="34ce48e722c206f299190088acea1e55ba420e99" resname="profile.my_connections.missing_connections">
         <source>profile.my_connections.missing_connections</source>
         <target>Missende koppelingen?</target>
-        <jms:reference-file line="86">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="85">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d8030c905e3901505ffa45585843d95d71cedb7a" resname="profile.my_connections.no_active_connections.description">
         <source>profile.my_connections.no_active_connections.description</source>
         <target>Je hebt nog geen actieve koppelingen.</target>
-        <jms:reference-file line="20">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="20">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ec33c82bf179989652928e2df38fcf975c378d95" resname="profile.my_connections.no_connections_configured.description">
         <source>profile.my_connections.no_connections_configured.description</source>
         <target>Op dit moment zijn er geen koppelingen beschikbaar die geconfigureerd kunnen worden.</target>
-        <jms:reference-file line="58">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="58">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d1a92495d8e08cf89bf517af5ffe5461407d2921" resname="profile.my_connections.orcid.connect_title">
         <source>profile.my_connections.orcid.connect_title</source>
         <target>Koppelen</target>
-        <jms:reference-file line="78">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="77">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c4b69512880a8532d9740e870ed8a60b8791b3bc" resname="profile.my_connections.orcid.description">
         <source>profile.my_connections.orcid.description</source>
         <target>ORCID is een alpha-numerieke code die wordt gebruikt om auteurs van wetenschappelijke werken uniek te identificeren.</target>
-        <jms:reference-file line="71">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="71">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4bc8f1ebcd9026ebbc6df9e128e3a1c0d4407ebd" resname="profile.my_connections.orcid.disconnect_title">
         <source>profile.my_connections.orcid.disconnect_title</source>
         <target>Ontkoppelen</target>
-        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bd50bc94d1957cd597c43c9a1eb6284461d48482" resname="profile.my_connections.orcid.status">
         <source>profile.my_connections.orcid.status</source>
         <target>Status</target>
-        <jms:reference-file line="34">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="34">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f36591d6cd52fa2b3b097b9cd4ca900700fe22e" resname="profile.my_connections.orcid.status_connected">
         <source>profile.my_connections.orcid.status_connected</source>
         <target>Gekoppeld</target>
-        <jms:reference-file line="35">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb0b77c5fd95698ab75dbd35962d63c0e76e9f2c" resname="profile.my_connections.orcid.title">
         <source>profile.my_connections.orcid.title</source>
         <target>ORCID</target>
-        <jms:reference-file line="27">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="30">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="67">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="27">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="67">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d8ba5b858f788ea3b20782b6d6a2653ab34581c" resname="profile.my_connections.send_request">
         <source>profile.my_connections.send_request</source>
         <target>Stuur ons een verzoek</target>
-        <jms:reference-file line="87">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="86">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d19d7e654594f5a24af2d7ccd23a3678082a0db4" resname="profile.my_connections.service_label">
         <source>profile.my_connections.service_label</source>
         <target>Service</target>
-        <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="66">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="66">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f61fad44caa0beb389084eb69cd3663855a1a3ac" resname="profile.my_connections.short_title">
         <source>profile.my_connections.short_title</source>
         <target>Mijn koppelingen</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b172b6b32cc00171f63b2834d2710be9a0e882fd" resname="profile.my_profile.attributes_information_link_title">
         <source>profile.my_profile.attributes_information_link_title</source>
         <target>Attributen in SURFconext</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="802fbec3f5be7a9a00873faea70d1513155e09c2" resname="profile.my_profile.introduction">
         <source>profile.my_profile.introduction</source>
         <target>De tabel hieronder biedt een overzicht van de persoonsgegevens die door jouw instelling via SURFconext kunnen worden doorgegeven aan diensten. In SURFconext worden jouw persoonsgegevens "attributen" genoemd. Een attribuut kan bijvoorbeeld je naam, e-mailadres of de naam van jouw instelling zijn. Voor technische informatie over deze attributen heeft SURFconext een aparte informatiepagina ingericht:</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="009b61d8df294d85f3271d872de139c7188473e2" resname="profile.my_profile.long_title">
         <source>profile.my_profile.long_title</source>
         <target>Informatie van jouw instelling</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a889019ee05f5be48abcfacba0b63235275ce299" resname="profile.my_profile.pi_processing">
         <source>profile.my_profile.pi_processing</source>
         <target>Op het tabblad "Mijn SURFconext" kan je zien welke attributen en gegevens SURFconext zelf opslaat.</target>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc93ed7bab761ec4c240fa28983bc1f069328991" resname="profile.my_profile.questions">
         <source>profile.my_profile.questions</source>
         <target>Let op: jouw instelling is verantwoordelijk voor de persoonsgegevens die je hier ziet. SURFconext laat slechts de informatie zien zoals ontvangen van jouw instelling. Heb je vragen over je persoonsgegevens? Neem dan contact op met je instelling via:</target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c35bcd376a8ad4ea3b6e7c4a297f3f8622d6927e" resname="profile.my_profile.questions_no_support_contact_email">
         <source>profile.my_profile.questions_no_support_contact_email</source>
         <target>Heb je vragen over je persoonsgegevens? Neem dan contact op met de helpdesk van je instelling.</target>
-        <jms:reference-file line="17">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="17">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f1e5e770356348259bcc4b16b55b4fbf30fdeed1" resname="profile.my_profile.short_title">
         <source>profile.my_profile.short_title</source>
         <target>Mijn profiel</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="41aded5ca8217152487f685b47f640799d76e24f" resname="profile.my_services.attribute_release_description">
         <source>profile.my_services.attribute_release_description</source>
         <target>Deze dienst ontvangt de volgende gegevens over jou:</target>
-        <jms:reference-file line="1">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="1">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="069a217bbb82a2da6a0c01cb25256919a35b62af" resname="profile.my_services.attribute_release_description_with_source">
         <source>profile.my_services.attribute_release_description_with_source</source>
         <target>Deze dienst ontvangt de volgende gegevens over jou van %source%:</target>
-        <jms:reference-file line="1">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
+        <jms:reference-file line="1">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cbc567af195fed58513777f183eafe22542178b1" resname="profile.my_services.consent_first_used_on">
         <source>profile.my_services.consent_first_used_on</source>
         <target>Voor het eerst gebruikt op</target>
-        <jms:reference-file line="55">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="55">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="927d4519f4715517225aa5df22bf583e6421a0cf" resname="profile.my_services.consent_type">
         <source>profile.my_services.consent_type</source>
         <target>Toestemming gegeven door</target>
-        <jms:reference-file line="45">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="45">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fc4ed9e167b467c2e26198429db9e75c2914cce6" resname="profile.my_services.error_loading_consent">
         <source>profile.my_services.error_loading_consent</source>
         <target>De lijst met diensten waar je bent ingelogd kan niet opgehaald worden.</target>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4fe6e0fef0fda46518eed058ae7a8411633d205d" resname="profile.my_services.eula">
         <source>profile.my_services.eula</source>
         <target>Gebruikersovereenkomst</target>
-        <jms:reference-file line="29">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="29">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e792a9988ccfee30143187c270b5e0dffc59020c" resname="profile.my_services.explanation">
         <source>profile.my_services.explanation</source>
         <target>Dit overzicht toont alle diensten waar je tenminste één keer op bent ingelogd via SURFconext. Ook kun je zien welk deel van jouw persoonsgegevens (attributen) vanuit jouw instelling naar de dienst is doorgestuurd. Daarnaast zie je of jij zelf of jouw instelling toestemming heeft gegeven voor het doorsturen van jouw attributen:</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a92f83f99644130d2de961b6add4752a8ed6c3cc" resname="profile.my_services.explanation.explicit_consent">
         <source>profile.my_services.explanation.explicit_consent</source>
         <target>Toestemming door jou: bij een aantal diensten wordt vooraf aan de eerste keer inloggen, expliciet gevraagd om toestemming voor het doorgeven van een aantal persoonsgegevens.</target>
-        <jms:reference-file line="11">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="11">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1903f16c642b35604024fbd11029cb099d14bb6e" resname="profile.my_services.explanation.implicit_consent">
         <source>profile.my_services.explanation.implicit_consent</source>
         <target>Toestemming door instelling: bij sommige diensten wordt niet expliciet toestemming aan jou gevraagd, maar worden de gegevens automatisch doorgegeven na inloggen. In deze gevallen heeft jouw instelling bepaald dat jouw expliciete toestemming niet nodig is. </target>
-        <jms:reference-file line="12">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="286aef124b54c35d42540b3c44ef082c8b86b363" resname="profile.my_services.explicit_consent_given">
         <source>profile.my_services.explicit_consent_given</source>
         <target>gebruiker</target>
-        <jms:reference-file line="48">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="48">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c815c74e5f7765a5d5e5c419a59bbff5f874a5be" resname="profile.my_services.implicit_consent_given">
         <source>profile.my_services.implicit_consent_given</source>
         <target>instelling</target>
-        <jms:reference-file line="50">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="50">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="107928a44903768c109c65916394c80a60c49e1e" resname="profile.my_services.long_title">
         <source>profile.my_services.long_title</source>
         <target>Diensten via SURFconext</target>
-        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="8">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f33a1baf8657a48868fa5624e490ca95134c5b96" resname="profile.my_services.no_attribute_released">
         <source>profile.my_services.no_attribute_released</source>
         <target>Deze dienst ontvangt geen gegevens over jou.</target>
-        <jms:reference-file line="63">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="63">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a56f9f031cd71cad0cbf03e1a523825720214a53" resname="profile.my_services.short_title">
         <source>profile.my_services.short_title</source>
         <target>Mijn diensten</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="47">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="15">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="15">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="22e22666c2969a24c385952a44da34ff2d808837" resname="profile.my_services.supportEmail">
         <source>profile.my_services.supportEmail</source>
         <target>E-mailadres support</target>
-        <jms:reference-file line="37">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="37">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="313af0cef887cdef1a6b4d5911515250d3010a25" resname="profile.my_surf_conext.account_data">
         <source>profile.my_surf_conext.account_data</source>
         <target>Accountgegevens</target>
-        <jms:reference-file line="12">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="12">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="88d5aa8d809e37e148138cabeb06a1f851d41ed0" resname="profile.my_surf_conext.account_data_explanation">
         <source>profile.my_surf_conext.account_data_explanation</source>
         <target>SURFconext kan (cloud)diensten een privacyvriendelijke identifier (nummer) geven waarmee jij herkend kan worden als je opnieuw inlogt bij een dienst. Om dit te kunnen doen, moet SURFconext jouw Gebruikers-ID en de naam van jouw instelling opslaan.</target>
-        <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2cceeab9b6a5ca79fdd2d506853f5292e1afb872" resname="profile.my_surf_conext.account_data_origin">
         <source>profile.my_surf_conext.account_data_origin</source>
         <target>Gebruikers-ID en de naam van jouw instelling + nummer gegenereerd door SURFconext</target>
-        <jms:reference-file line="19">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="19">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="85dde9b709fc5f0684d02cec3d797f669f3dd001" resname="profile.my_surf_conext.account_data_retention_period">
         <source>profile.my_surf_conext.account_data_retention_period</source>
         <target>Tot 3 jaar na laatste inlog.</target>
-        <jms:reference-file line="23">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="23">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="be73e1bc34923830cbb8c48bfc1697af4b1a827a" resname="profile.my_surf_conext.consent_data">
         <source>profile.my_surf_conext.consent_data</source>
         <target>Toestemmingsgegevens</target>
-        <jms:reference-file line="46">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="46">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a4a1d52b47f79dbd7e6c21302010b061e897565" resname="profile.my_surf_conext.consent_data_explanation">
         <source>profile.my_surf_conext.consent_data_explanation</source>
         <target>Bij de meeste diensten moet je, voordat je voor de eerste keer inlogt, expliciet toestemming geven om jouw attributen te delen met de dienst waar je wilt inloggen. SURFconext slaat op wanneer en voor welke dienst je deze toestemming hebt gegeven. Meer over welke gegevens je per dienst heb gedeeld, vind je onder</target>
-        <jms:reference-file line="47">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="47">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="972f4bcdbdd3c6aa6acabcbac0942c53cf33b6e8" resname="profile.my_surf_conext.consent_data_origin">
         <source>profile.my_surf_conext.consent_data_origin</source>
         <target>Gegenereerd door SURFconext</target>
-        <jms:reference-file line="53">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="53">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fadb692e51d3071903f8e51749e57a5b989c8ecc" resname="profile.my_surf_conext.consent_data_retention_period">
         <source>profile.my_surf_conext.consent_data_retention_period</source>
         <target>Tot 3 jaar na laatste inlog.</target>
-        <jms:reference-file line="57">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="57">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="602265c6c69cb0a3e3ba202914cb1efc16e95f1c" resname="profile.my_surf_conext.data_origin">
         <source>profile.my_surf_conext.data_origin</source>
         <target>Gegevens en herkomst</target>
-        <jms:reference-file line="18">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="18">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5169f77f250fabf4445380d02e986b37f9ad10d7" resname="profile.my_surf_conext.data_retention_period">
         <source>profile.my_surf_conext.data_retention_period</source>
         <target>Bewaartermijn</target>
-        <jms:reference-file line="22">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="39">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="56">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="22">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="39">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="56">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37d164bfb27988f8a5a5e4882401b8df2142740d" resname="profile.my_surf_conext.introduction">
         <source>profile.my_surf_conext.introduction</source>
         <target>SURFconext slaat gegevens op om je eenvoudig en veilig in te kunnen laten loggen bij verschillende (cloud)diensten en om jou inzicht te geven waar je allemaal bent ingelogd. Jouw instelling bepaalt welke diensten voor jou toegankelijk zijn via SURFconext. De meeste diensten die je via SURFconext benadert krijgen een klein deel van jouw gegevens. Sommige diensten hebben helemaal geen persoonsgegevens nodig. Als je wilt zien welke dienst welke gegevens krijgt, kijk dan bij %my_services_link%.</target>
-        <jms:reference-file line="10">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="10">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="198dce1e77b95dfaa8e56ec5ba8f44a46bf69215" resname="profile.my_surf_conext.logging_data">
         <source>profile.my_surf_conext.logging_data</source>
         <target>Loggegevens</target>
-        <jms:reference-file line="29">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="29">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9d699ca9640ad2fe880c19c29007cbe30dd3d378" resname="profile.my_surf_conext.logging_data_explanation">
         <source>profile.my_surf_conext.logging_data_explanation</source>
         <target>SURFconext bewaart tijdelijk wanneer en vanaf welk IP-adres je gebruik maakt van SURFconext en bij welke diensten je hebt ingelogd. Dit is nodig voor het beheer en de beveiliging van SURFconext.</target>
-        <jms:reference-file line="30">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="30">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eaf93e5a9f8e999a138ecfb99ce5e7ff95bb7f86" resname="profile.my_surf_conext.logging_data_origin">
         <source>profile.my_surf_conext.logging_data_origin</source>
         <target>Gegenereerd door SURFconext</target>
-        <jms:reference-file line="36">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="36">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="caddd61ed1171bbd0b0f996b78c6fcbbcffc356a" resname="profile.my_surf_conext.logging_data_retention_period">
         <source>profile.my_surf_conext.logging_data_retention_period</source>
         <target>6 maanden. Na 6 maanden worden de logbestanden geanonimiseerd.</target>
-        <jms:reference-file line="40">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="40">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="128b376e6b372c962506ec6b3bd7ba92a69f71f1" resname="profile.my_surf_conext.long_title">
         <source>profile.my_surf_conext.long_title</source>
         <target>Details van jouw SURFconext-profiel</target>
-        <jms:reference-file line="9">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="90932e1aff99c6f99c5807eec180c40db5a32485" resname="profile.my_surf_conext.origin">
         <source>profile.my_surf_conext.origin</source>
         <target>Herkomst</target>
-        <jms:reference-file line="35">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="52">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="52">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="010ed9d837beee859a1f028bf9748f9ab7b31a4e" resname="profile.my_surf_conext.short_title">
         <source>profile.my_surf_conext.short_title</source>
         <target>Mijn SURFconext</target>
-        <jms:reference-file line="4">/../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="21">/../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
+        <jms:reference-file line="4">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MySurfConext/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../../../../../src/OpenConext/ProfileBundle/Resources/views/navigation-tabs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc8455ffe1c5bde28802e8445e31e3d1f5c12a7a" resname="profile.navigation.help">
         <source>profile.navigation.help</source>
         <target>Help</target>
-        <jms:reference-file line="26">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
-        <jms:reference-file line="79">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="26">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="79">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="73f3979adec1e8f8b69cd5b18c0bdad323cde224" resname="profile.navigation.terms_of_service">
         <source>profile.navigation.terms_of_service</source>
         <target>Gebruiksvoorwaarden</target>
-        <jms:reference-file line="82">/../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+        <jms:reference-file line="82">/../../../../../src/OpenConext/ProfileBundle/Resources/views/layout.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="f5d0957a4421ee6ecaf81e9c8a568650a015770a" resname="profile.saml.attributes.eduPersonTargetedId.persistent">
+        <source>profile.saml.attributes.eduPersonTargetedId.persistent</source>
+        <target>Pseudoniem dat per dienst verschilt</target>
+        <jms:reference-file line="34">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="6dfc05705bd5f8f27a26d62e7826aebaeecd4d15" resname="profile.saml.attributes.eduPersonTargetedId.transient">
+        <source>profile.saml.attributes.eduPersonTargetedId.transient</source>
+        <target>Pseudoniem dat per login verschilt</target>
+        <jms:reference-file line="32">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3c4f154ed62c838e29dc22974f574af5cb2b2f8e" resname="profile.table.attribute_name">
         <source>profile.table.attribute_name</source>
         <target>Attribuut</target>
-        <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="13">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="24">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="6">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
-        <jms:reference-file line="6">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="13">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="24">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/aa.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="547ea301afc0bae2bdbdedec6915fa51c654ff52" resname="profile.table.attribute_value">
         <source>profile.table.attribute_value</source>
         <target>Waarde</target>
-        <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="25">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
-        <jms:reference-file line="7">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../src/OpenConext/ProfileBundle/Resources/views/AttributeSupport/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="14">/../../../../../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="25">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../../../../../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0116d16056d9cd75bfe4bf170b5b504d8b939a38" resname="profile.table.source_description.orcid">
         <source>profile.table.source_description.orcid</source>
         <target>ORCID iD</target>
-        <jms:reference-file line="175">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="175">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e591d4c6d94037cb4aca3294d989e63eeb15663f" resname="profile.table.source_description.sab">
         <source>profile.table.source_description.sab</source>
         <target>SURFnet Autorisatie Beheer</target>
-        <jms:reference-file line="176">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="176">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="7eaa211c78eb7290993519c729e4e05c49269da3" resname="profile.table.source_description.surfmarket_entitlements">
+      <trans-unit id="98a7e142496864319f0b2c6b931da715b4e000db" resname="profile.table.source_description.surfmarket_entitlements">
         <source>profile.table.source_description.surfmarket_entitlements</source>
         <target>SURFmarket Entitlements</target>
-        <jms:reference-file line="177">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="177">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4b1c5ddcfd432d3477264f068b21ff7996915e06" resname="profile.table.source_description.voot">
         <source>profile.table.source_description.voot</source>
         <target>Groepslidmaatschap</target>
-        <jms:reference-file line="174">/../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
+        <jms:reference-file line="174">/../../../../../src/OpenConext/ProfileBundle/Resources/views/translations.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
@@ -59,6 +59,8 @@ final class ConsentListFactoryTest extends TestCase
                     'eula_url'      => $firstEula,
                     'support_email' => null,
                     'name_id_format' => 'test',
+                    'support_url_en' => 'https://example.org/support-en',
+                    'support_url_nl' => 'https://example.org/support-nl',
                 ],
                 'consent_given_on' => '2015-11-05T08:43:01+01:00',
                 'consent_type'     => $givenFirstConsentTypeValue
@@ -70,6 +72,8 @@ final class ConsentListFactoryTest extends TestCase
                     'eula_url'      => null,
                     'support_email' => $secondSupportEmail,
                     'name_id_format' => 'test',
+                    'support_url_en' => 'https://example.org/support-en',
+                    'support_url_nl' => 'https://example.org/support-nl',
                 ],
                 'consent_given_on' => '2015-11-05T08:17:04+01:00',
                 'consent_type'     => $givenSecondConsentTypeValue
@@ -83,7 +87,9 @@ final class ConsentListFactoryTest extends TestCase
                     new DisplayName(['nl' => '', 'en' => '']),
                     new NameIdFormat('test'),
                     new Url($firstEula),
-                    null
+                    null,
+                    new Url('https://example.org/support-en'),
+                    new Url('https://example.org/support-nl')
                 ),
                 new DateTimeImmutable('2015-11-05T08:43:01+01:00'),
                 $expectedFirstConsentType
@@ -94,7 +100,9 @@ final class ConsentListFactoryTest extends TestCase
                     new DisplayName(['nl' => 'OpenConext ServiceRegistry', 'en' => 'OpenConext ServiceRegistry']),
                     new NameIdFormat('test'),
                     null,
-                    new ContactEmailAddress($secondSupportEmail)
+                    new ContactEmailAddress($secondSupportEmail),
+                    new Url('https://example.org/support-en'),
+                    new Url('https://example.org/support-nl')
                 ),
                 new DateTimeImmutable('2015-11-05T08:17:04+01:00'),
                 $expectedSecondConsentType

--- a/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
@@ -29,6 +29,7 @@ use OpenConext\Profile\Value\ContactEmailAddress;
 use OpenConext\Profile\Value\Entity;
 use OpenConext\Profile\Value\EntityId;
 use OpenConext\Profile\Value\EntityType;
+use OpenConext\Profile\Value\NameIdFormat;
 use OpenConext\Profile\Value\Url;
 use PHPUnit\Framework\TestCase;
 
@@ -57,6 +58,7 @@ final class ConsentListFactoryTest extends TestCase
                     'display_name'  => ['en' => '', 'nl' => '',],
                     'eula_url'      => $firstEula,
                     'support_email' => null,
+                    'name_id_format' => 'test',
                 ],
                 'consent_given_on' => '2015-11-05T08:43:01+01:00',
                 'consent_type'     => $givenFirstConsentTypeValue
@@ -67,6 +69,7 @@ final class ConsentListFactoryTest extends TestCase
                     'display_name'  => ['en' => 'OpenConext ServiceRegistry', 'nl' => 'OpenConext ServiceRegistry'],
                     'eula_url'      => null,
                     'support_email' => $secondSupportEmail,
+                    'name_id_format' => 'test',
                 ],
                 'consent_given_on' => '2015-11-05T08:17:04+01:00',
                 'consent_type'     => $givenSecondConsentTypeValue
@@ -78,6 +81,7 @@ final class ConsentListFactoryTest extends TestCase
                 new ServiceProvider(
                     new Entity(new EntityId($firstEntityId), EntityType::SP()),
                     new DisplayName(['nl' => '', 'en' => '']),
+                    new NameIdFormat('test'),
                     new Url($firstEula),
                     null
                 ),
@@ -88,6 +92,7 @@ final class ConsentListFactoryTest extends TestCase
                 new ServiceProvider(
                     new Entity(new EntityId($secondEntityId), EntityType::SP()),
                     new DisplayName(['nl' => 'OpenConext ServiceRegistry', 'en' => 'OpenConext ServiceRegistry']),
+                    new NameIdFormat('test'),
                     null,
                     new ContactEmailAddress($secondSupportEmail)
                 ),

--- a/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
@@ -109,12 +109,16 @@ final class ConsentListFactory
         Assert::keyExists($data, 'eula_url', 'Consent JSON structure must contain key "eula_url"');
         Assert::keyExists($data, 'support_email', 'Consent JSON structure must contain key "support_email"');
         Assert::keyExists($data, 'name_id_format', 'Consent JSON structure must contain key "name_id_format"');
+        Assert::keyExists($data, 'support_url_en', 'Consent JSON structure must contain key "support_url_en"');
+        Assert::keyExists($data, 'support_url_nl', 'Consent JSON structure must contain key "support_url_nl"');
 
         $entity       = new Entity(new EntityId($data['entity_id']), EntityType::SP());
         $displayName  = new DisplayName($data['display_name']);
         $nameIdFormat = new NameIdFormat($data['name_id_format']);
         $eulaUrl      = null;
         $supportEmail = null;
+        $supportUrlEn = null;
+        $supportUrlNl = null;
 
         if ($data['eula_url'] !== null) {
             $eulaUrl = new Url($data['eula_url']);
@@ -124,6 +128,22 @@ final class ConsentListFactory
             $supportEmail = new ContactEmailAddress($data['support_email']);
         }
 
-        return new ServiceProvider($entity, $displayName, $nameIdFormat, $eulaUrl, $supportEmail);
+        if ($data['support_url_en'] !== null) {
+            $supportUrlEn = new Url($data['support_url_en']);
+        }
+
+        if ($data['support_url_nl'] !== null) {
+            $supportUrlNl = new Url($data['support_url_nl']);
+        }
+
+        return new ServiceProvider(
+            $entity,
+            $displayName,
+            $nameIdFormat,
+            $eulaUrl,
+            $supportEmail,
+            $supportUrlEn,
+            $supportUrlNl
+        );
     }
 }

--- a/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
@@ -26,6 +26,7 @@ use OpenConext\Profile\Value\Consent\ServiceProvider;
 use OpenConext\Profile\Value\ConsentList;
 use OpenConext\Profile\Value\ConsentType;
 use OpenConext\Profile\Value\DisplayName;
+use OpenConext\Profile\Value\NameIdFormat;
 use OpenConext\Profile\Value\ContactEmailAddress;
 use OpenConext\Profile\Value\Entity;
 use OpenConext\Profile\Value\EntityId;
@@ -107,9 +108,11 @@ final class ConsentListFactory
         Assert::keyExists($data, 'display_name', 'Consent JSON structure must contain key "display_name"');
         Assert::keyExists($data, 'eula_url', 'Consent JSON structure must contain key "eula_url"');
         Assert::keyExists($data, 'support_email', 'Consent JSON structure must contain key "support_email"');
+        Assert::keyExists($data, 'name_id_format', 'Consent JSON structure must contain key "name_id_format"');
 
         $entity       = new Entity(new EntityId($data['entity_id']), EntityType::SP());
         $displayName  = new DisplayName($data['display_name']);
+        $nameIdFormat = new NameIdFormat($data['name_id_format']);
         $eulaUrl      = null;
         $supportEmail = null;
 
@@ -121,6 +124,6 @@ final class ConsentListFactory
             $supportEmail = new ContactEmailAddress($data['support_email']);
         }
 
-        return new ServiceProvider($entity, $displayName, $eulaUrl, $supportEmail);
+        return new ServiceProvider($entity, $displayName, $nameIdFormat, $eulaUrl, $supportEmail);
     }
 }

--- a/src/OpenConext/Profile/Tests/Value/SpecifiedConsentTest.php
+++ b/src/OpenConext/Profile/Tests/Value/SpecifiedConsentTest.php
@@ -28,6 +28,7 @@ use OpenConext\Profile\Value\DisplayName;
 use OpenConext\Profile\Value\Entity;
 use OpenConext\Profile\Value\EntityId;
 use OpenConext\Profile\Value\EntityType;
+use OpenConext\Profile\Value\NameIdFormat;
 use OpenConext\Profile\Value\SpecifiedConsent;
 use OpenConext\Profile\Value\Url;
 use OpenConext\ProfileBundle\Attribute\AttributeSetWithFallbacks;
@@ -55,6 +56,7 @@ class SpecifiedConsentTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
             ),
@@ -93,6 +95,7 @@ class SpecifiedConsentTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
             ),
@@ -123,6 +126,7 @@ class SpecifiedConsentTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
             ),
@@ -150,6 +154,7 @@ class SpecifiedConsentTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
             ),

--- a/src/OpenConext/Profile/Value/Consent/ServiceProvider.php
+++ b/src/OpenConext/Profile/Value/Consent/ServiceProvider.php
@@ -21,6 +21,7 @@ namespace OpenConext\Profile\Value\Consent;
 use OpenConext\EngineBlockApiClientBundle\Exception\LogicException;
 use OpenConext\Profile\Assert;
 use OpenConext\Profile\Value\DisplayName;
+use OpenConext\Profile\Value\NameIdFormat;
 use OpenConext\Profile\Value\ContactEmailAddress;
 use OpenConext\Profile\Value\Entity;
 use OpenConext\Profile\Value\Url;
@@ -38,6 +39,11 @@ final class ServiceProvider
     private $displayName;
 
     /**
+     * @var NameIdFormat
+     */
+    private $nameIdFormat;
+
+    /**
      * @var Url|null
      */
     private $eulaUrl;
@@ -50,11 +56,13 @@ final class ServiceProvider
     public function __construct(
         Entity $entity,
         DisplayName $displayName,
+        NameIdFormat $nameIdFormat,
         Url $eulaUrl = null,
         ContactEmailAddress $supportEmail = null
     ) {
         $this->entity       = $entity;
         $this->displayName  = $displayName;
+        $this->nameIdFormat = $nameIdFormat;
         $this->eulaUrl      = $eulaUrl;
         $this->supportEmail = $supportEmail;
     }
@@ -73,6 +81,14 @@ final class ServiceProvider
     public function getDisplayName()
     {
         return $this->displayName;
+    }
+
+    /**
+     * @return NameIdFormat
+     */
+    public function getNameIdFormat()
+    {
+        return $this->nameIdFormat;
     }
 
     /**

--- a/src/OpenConext/Profile/Value/Consent/ServiceProvider.php
+++ b/src/OpenConext/Profile/Value/Consent/ServiceProvider.php
@@ -53,18 +53,32 @@ final class ServiceProvider
      */
     private $supportEmail;
 
+    /**
+     * @var Url|null
+     */
+    private $supportUrlEn;
+
+    /**
+     * @var Url|null
+     */
+    private $supportUrlNl;
+
     public function __construct(
         Entity $entity,
         DisplayName $displayName,
         NameIdFormat $nameIdFormat,
         Url $eulaUrl = null,
-        ContactEmailAddress $supportEmail = null
+        ContactEmailAddress $supportEmail = null,
+        Url $supportUrlEn = null,
+        Url $supportUrlNl = null
     ) {
         $this->entity       = $entity;
         $this->displayName  = $displayName;
         $this->nameIdFormat = $nameIdFormat;
         $this->eulaUrl      = $eulaUrl;
         $this->supportEmail = $supportEmail;
+        $this->supportUrlEn = $supportUrlEn;
+        $this->supportUrlNl = $supportUrlNl;
     }
 
     /**
@@ -144,5 +158,31 @@ final class ServiceProvider
         }
 
         return $this->supportEmail;
+    }
+
+    /**
+     * @param string $locale
+     * @return null|Url
+     */
+    public function getSupportUrl($locale)
+    {
+        if ($locale === 'nl') {
+            return $this->supportUrlNl;
+        } else {
+            return $this->supportUrlEn;
+        }
+    }
+
+    /**
+     * @param $locale
+     * @return bool
+     */
+    public function hasSupportUrl($locale)
+    {
+        if ($locale === 'nl') {
+            return $this->supportUrlNl !== null;
+        } else {
+            return $this->supportUrlEn !== null;
+        }
     }
 }

--- a/src/OpenConext/Profile/Value/NameIdFormat.php
+++ b/src/OpenConext/Profile/Value/NameIdFormat.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2018 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\Profile\Value;
+
+use OpenConext\Profile\Assert;
+
+final class NameIdFormat
+{
+    const PERSISTENT_IDENTIFIER = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent';
+    const TRANSIENT_IDENTIFIER  = 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient';
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        Assert::string($value, 'NameIDFormat "%s" must be a string');
+
+        $this->value = $value;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPersistent()
+    {
+        return $this->value === self::PERSISTENT_IDENTIFIER;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTransient()
+    {
+        return $this->value === self::TRANSIENT_IDENTIFIER;
+    }
+}

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
@@ -25,9 +25,19 @@
                 {% endif %}
             </td>
             <td>
-                {% for attributeValue in attribute.value  %}
-                    <p class="attribute-value">{{ attributeValue.value }}</p>
-                {% endfor %}
+                {% if attribute.attributeDefinition.name == 'eduPersonTargetedID' and (
+                        specifiedConsent.consent.serviceProvider.nameIdFormat.isTransient or
+                        specifiedConsent.consent.serviceProvider.nameIdFormat.isPersistent) %}
+                    {% if specifiedConsent.consent.serviceProvider.nameIdFormat.isTransient %}
+                        <em>{{ 'profile.saml.attributes.eduPersonTargetedId.transient'|trans }}</em>
+                    {%  else %}
+                        <em>{{ 'profile.saml.attributes.eduPersonTargetedId.persistent'|trans }}</em>
+                    {%  endif %}
+                {% else %}
+                    {% for attributeValue in attribute.value  %}
+                        <p class="attribute-value">{{ attributeValue.value }}</p>
+                    {% endfor %}
+                {% endif %}
             </td>
         </tr>
     {% endfor %}

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/overview.html.twig
@@ -32,6 +32,16 @@
                                 </td>
                             </tr>
                             {% endif %}
+                            {% if specifiedConsent.consent.serviceProvider.hasSupportUrl(app.request.locale) %}
+                                <tr>
+                                    <td>{{ 'profile.my_services.support_url'|trans }}:</td>
+                                    <td>
+                                        <a href="{{ specifiedConsent.consent.serviceProvider.getSupportUrl(app.request.locale) }}">
+                                            {{ specifiedConsent.consent.serviceProvider.getSupportUrl(app.request.locale) }}
+                                        </a>
+                                    </td>
+                                </tr>
+                            {% endif %}
                             {% if specifiedConsent.consent.serviceProvider.hasSupportEmail %}
                             <tr>
                                 <td>{{ 'profile.my_services.supportEmail'|trans }}:</td>

--- a/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
+++ b/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
@@ -32,6 +32,7 @@ use OpenConext\Profile\Value\DisplayName;
 use OpenConext\Profile\Value\Entity;
 use OpenConext\Profile\Value\EntityId;
 use OpenConext\Profile\Value\EntityType;
+use OpenConext\Profile\Value\NameIdFormat;
 use OpenConext\Profile\Value\SpecifiedConsent;
 use OpenConext\Profile\Value\SpecifiedConsentList;
 use OpenConext\Profile\Value\Url;
@@ -167,6 +168,7 @@ class AttributeReleasePolicyServiceTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
             ),
@@ -182,6 +184,7 @@ class AttributeReleasePolicyServiceTest extends TestCase
                 new DisplayName([
                     'en' =>'Another display name'
                 ]),
+                new NameIdFormat(''),
                 new Url('http://another-eula-url.example'),
                 new ContactEmailAddress('another@email.example')
             ),


### PR DESCRIPTION
Note: this PR includes #101, so test that one first!

This requires EB5.5.2 after hotfix1, or EB>5.5.4 or EB>5.6.3 or EB>=5.7.

The EB consent API now sends the support urls (en/nl) along with the consent data, and this is displayed on the 'My Services' page.

See: https://www.pivotaltracker.com/story/show/107474726
And: OpenConext/OpenConext-engineblock#520