### PR TITLE
Remove duplicate 'support_url' in consent API response

### DIFF
--- a/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
@@ -56,11 +56,10 @@ final class ConsentListFactoryTest extends TestCase
                 'service_provider' => [
                     'entity_id'     => $firstEntityId,
                     'display_name'  => ['en' => '', 'nl' => '',],
+                    'support_url'  => ['en' => 'https://example.org/support-en', 'nl' => 'https://example.org/support-nl'],
                     'eula_url'      => $firstEula,
                     'support_email' => null,
                     'name_id_format' => 'test',
-                    'support_url_en' => 'https://example.org/support-en',
-                    'support_url_nl' => 'https://example.org/support-nl',
                 ],
                 'consent_given_on' => '2015-11-05T08:43:01+01:00',
                 'consent_type'     => $givenFirstConsentTypeValue
@@ -69,11 +68,10 @@ final class ConsentListFactoryTest extends TestCase
                 'service_provider' => [
                     'entity_id'     => $secondEntityId,
                     'display_name'  => ['en' => 'OpenConext ServiceRegistry', 'nl' => 'OpenConext ServiceRegistry'],
+                    'support_url'  => ['en' => 'https://example.org/support-en', 'nl' => 'https://example.org/support-nl'],
                     'eula_url'      => null,
                     'support_email' => $secondSupportEmail,
                     'name_id_format' => 'test',
-                    'support_url_en' => 'https://example.org/support-en',
-                    'support_url_nl' => 'https://example.org/support-nl',
                 ],
                 'consent_given_on' => '2015-11-05T08:17:04+01:00',
                 'consent_type'     => $givenSecondConsentTypeValue

--- a/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Value/ConsentListFactory.php
@@ -109,8 +109,7 @@ final class ConsentListFactory
         Assert::keyExists($data, 'eula_url', 'Consent JSON structure must contain key "eula_url"');
         Assert::keyExists($data, 'support_email', 'Consent JSON structure must contain key "support_email"');
         Assert::keyExists($data, 'name_id_format', 'Consent JSON structure must contain key "name_id_format"');
-        Assert::keyExists($data, 'support_url_en', 'Consent JSON structure must contain key "support_url_en"');
-        Assert::keyExists($data, 'support_url_nl', 'Consent JSON structure must contain key "support_url_nl"');
+        Assert::keyExists($data, 'support_url', 'Consent JSON structure must contain key "support_url"');
 
         $entity       = new Entity(new EntityId($data['entity_id']), EntityType::SP());
         $displayName  = new DisplayName($data['display_name']);
@@ -128,12 +127,12 @@ final class ConsentListFactory
             $supportEmail = new ContactEmailAddress($data['support_email']);
         }
 
-        if ($data['support_url_en'] !== null) {
-            $supportUrlEn = new Url($data['support_url_en']);
+        if (isset($data['support_url']['en'])) {
+            $supportUrlEn = new Url($data['support_url']['en']);
         }
 
-        if ($data['support_url_nl'] !== null) {
-            $supportUrlNl = new Url($data['support_url_nl']);
+        if (isset($data['support_url']['nl'])) {
+            $supportUrlNl = new Url($data['support_url']['nl']);
         }
 
         return new ServiceProvider(


### PR DESCRIPTION
EB previously sent the support URL in the 'support_url' and
'support_url_*' fields, the latter was removed in EB5.7 and this
commit updates profile to support that change.

See https://github.com/OpenConext/OpenConext-engineblock/pull/532