### PR TITLE
Support service providers without NameIDFormat

### DIFF
--- a/src/OpenConext/Profile/Value/NameIdFormat.php
+++ b/src/OpenConext/Profile/Value/NameIdFormat.php
@@ -35,6 +35,16 @@ final class NameIdFormat
      */
     public function __construct($value)
     {
+        // A service provider usually always has a NameIDFormat, because it's
+        // required by the manage web interface.
+        //
+        // In practice, programmatically created entities can be saved
+        // without NameIDFormat. In those cases, we fall back to most likely
+        // used value by EngineBlock: persistent.
+        if ($value === null) {
+            $value = self::PERSISTENT_IDENTIFIER;
+        }
+
         Assert::string($value, 'NameIDFormat "%s" must be a string');
 
         $this->value = $value;


### PR DESCRIPTION
Entities created with the manage API can be saved without
NameIDFormat, to support those edge-cases we fall back to the most
likely used value by EngineBlock, which is the persistent format.

See https://www.pivotaltracker.com/story/show/157808713