### PR TITLE
Include arp motivations

### DIFF
--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-06T16:24:24Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2018-06-21T16:11:45Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -510,12 +510,12 @@ This profile page gives you insight in which personal data, provided by your ins
       <trans-unit id="f5d0957a4421ee6ecaf81e9c8a568650a015770a" resname="profile.saml.attributes.eduPersonTargetedId.persistent">
         <source>profile.saml.attributes.eduPersonTargetedId.persistent</source>
         <target>Pseudonym that differs for each service</target>
-        <jms:reference-file line="34">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6dfc05705bd5f8f27a26d62e7826aebaeecd4d15" resname="profile.saml.attributes.eduPersonTargetedId.transient">
         <source>profile.saml.attributes.eduPersonTargetedId.transient</source>
         <target>Pseudonym that changes with every login</target>
-        <jms:reference-file line="32">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3c4f154ed62c838e29dc22974f574af5cb2b2f8e" resname="profile.table.attribute_name">
         <source>profile.table.attribute_name</source>
@@ -533,6 +533,11 @@ This profile page gives you insight in which personal data, provided by your ins
         <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
         <jms:reference-file line="25">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
         <jms:reference-file line="7">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="3dfefde5aa8265c36d1a1d339595faa14c89eaa7" resname="profile.table.motivation">
+        <source>profile.table.motivation</source>
+        <target>Motivation</target>
+        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0116d16056d9cd75bfe4bf170b5b504d8b939a38" resname="profile.table.source_description.orcid">
         <source>profile.table.source_description.orcid</source>

--- a/app/Resources/translations/messages.nl.xliff
+++ b/app/Resources/translations/messages.nl.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2018-03-06T16:24:26Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
+  <file date="2018-06-21T16:11:46Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -511,12 +511,12 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
       <trans-unit id="f5d0957a4421ee6ecaf81e9c8a568650a015770a" resname="profile.saml.attributes.eduPersonTargetedId.persistent">
         <source>profile.saml.attributes.eduPersonTargetedId.persistent</source>
         <target>Pseudoniem dat per dienst verschilt</target>
-        <jms:reference-file line="34">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="35">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6dfc05705bd5f8f27a26d62e7826aebaeecd4d15" resname="profile.saml.attributes.eduPersonTargetedId.transient">
         <source>profile.saml.attributes.eduPersonTargetedId.transient</source>
         <target>Pseudoniem dat per login verschilt</target>
-        <jms:reference-file line="32">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+        <jms:reference-file line="33">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3c4f154ed62c838e29dc22974f574af5cb2b2f8e" resname="profile.table.attribute_name">
         <source>profile.table.attribute_name</source>
@@ -534,6 +534,11 @@ Deze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jo
         <jms:reference-file line="14">/../src/OpenConext/ProfileBundle/Resources/views/InformationRequest/overview.html.twig</jms:reference-file>
         <jms:reference-file line="25">/../src/OpenConext/ProfileBundle/Resources/views/MyProfile/overview.html.twig</jms:reference-file>
         <jms:reference-file line="7">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="3dfefde5aa8265c36d1a1d339595faa14c89eaa7" resname="profile.table.motivation">
+        <source>profile.table.motivation</source>
+        <target>Motivatie</target>
+        <jms:reference-file line="8">/../src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0116d16056d9cd75bfe4bf170b5b504d8b939a38" resname="profile.table.source_description.orcid">
         <source>profile.table.source_description.orcid</source>

--- a/src/OpenConext/Profile/Tests/Value/ArpTest.php
+++ b/src/OpenConext/Profile/Tests/Value/ArpTest.php
@@ -121,7 +121,6 @@ class ArpTest extends TestCase
             [['urn.mace.foobar' => [['invalid-key' => null]]]],
             [['urn.mace.foobar' => [['source' => new StdClass()]]]],
             [['urn.mace.foobar' => [['value' => new StdClass()]]]],
-            [['urn.mace.foobar' => [['value' => '*', 'sourcy' => 'fff']]]],
             [['urn.mace.foobar' => [['value' => '*', 'source' => []]]]],
             [['urn.mace.foobar' => [['value' => '*'], ['value' => '*', 'source' => []]]]],
         ];

--- a/src/OpenConext/Profile/Value/Arp.php
+++ b/src/OpenConext/Profile/Value/Arp.php
@@ -122,16 +122,15 @@ final class Arp
     private static function isValidAttribute(array $attributeInformation)
     {
         foreach ($attributeInformation as $attributeInformationEntry) {
-            if (!array_key_exists('value', $attributeInformationEntry)) {
+            if (!isset($attributeInformationEntry['value'])) {
                 return false;
             }
 
-            foreach ($attributeInformationEntry as $key => $value) {
+            foreach ($attributeInformationEntry as $value) {
                 if (!is_string($value)) {
                     return false;
                 }
             }
-
         }
         return true;
     }
@@ -149,5 +148,38 @@ final class Arp
     public function getAttributesGroupedBySource()
     {
         return $this->arp;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasMotivations()
+    {
+        foreach ($this->arp as $arpSource) {
+            foreach ($arpSource as $arpEntry) {
+                $values = $arpEntry->getValue();
+                $attributeValue = reset($values);
+                if (isset($attributeValue['motivation'])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public function getMotivationFor(Attribute $attribute)
+    {
+        foreach ($this->arp as $arpSource) {
+            foreach ($arpSource as $arpEntry) {
+                if ($attribute->getAttributeDefinition()->getUrnMace() == $arpEntry->getAttributeDefinition()->getUrnMace()) {
+                    $values = $arpEntry->getValue();
+                    $attributeValue = reset($values);
+                    if (isset($attributeValue['motivation'])) {
+                        return $attributeValue['motivation'];
+                    }
+                }
+            }
+        }
+        return '';
     }
 }

--- a/src/OpenConext/Profile/Value/Arp.php
+++ b/src/OpenConext/Profile/Value/Arp.php
@@ -82,7 +82,8 @@ final class Arp
      * Tests the structure of the Arp attribute information.
      *
      * This information should be an array, should have the attribute names as its keys and have array values.
-     * These array values can have two keys (value & source) the values aof these entries should be string.
+     * These array values can have three keys (value, source and motivation) the values of these entries should
+     * be of type string.
      *
      * Example of a valid attribute information array:
      *
@@ -106,6 +107,13 @@ final class Arp
      *       'source' => 'orcid',
      *     ],
      *   ],
+     *   'urn.mace.eduPersonAffiliation' => [
+     *     [
+     *       'value' => '*',
+     *       'source' => 'sab',
+     *       'motivation' => 'A motivation provided by the SP.'
+     *     ]
+     *   ],
      * ]
      *
      * @param array $attributeInformation
@@ -113,17 +121,17 @@ final class Arp
      */
     private static function isValidAttribute(array $attributeInformation)
     {
-        $validKeys = ['value', 'source'];
-
         foreach ($attributeInformation as $attributeInformationEntry) {
-            foreach ($attributeInformationEntry as $key => $attributeConfigValue) {
-                if (!in_array($key, $validKeys)) {
-                    return false;
-                }
-                if (!is_string($attributeConfigValue)) {
+            if (!array_key_exists('value', $attributeInformationEntry)) {
+                return false;
+            }
+
+            foreach ($attributeInformationEntry as $key => $value) {
+                if (!is_string($value)) {
                     return false;
                 }
             }
+
         }
         return true;
     }

--- a/src/OpenConext/Profile/Value/SpecifiedConsent.php
+++ b/src/OpenConext/Profile/Value/SpecifiedConsent.php
@@ -112,4 +112,17 @@ class SpecifiedConsent
 
         return $grouped;
     }
+
+    /**
+     * @return bool
+     */
+    public function hasMotivations()
+    {
+        return $this->arp->hasMotivations();
+    }
+
+    public function getMotivation(Attribute $attribute)
+    {
+        return $this->arp->getMotivationFor($attribute);
+    }
 }

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
@@ -1,10 +1,12 @@
 <p>{{ 'profile.my_services.attribute_release_description'|trans }}</p>
-
 <table class="mdl-data-table">
     <thead>
     <tr>
         <th>{{ 'profile.table.attribute_name'|trans }}</th>
         <th>{{ 'profile.table.attribute_value'|trans }}</th>
+        {% if specifiedConsent.hasMotivations %}
+            <th>{{ 'profile.table.motivation'|trans }}</th>
+        {% endif %}
     </tr>
     </thead>
     <tbody>
@@ -39,6 +41,11 @@
                     {% endfor %}
                 {% endif %}
             </td>
+            {% if specifiedConsent.hasMotivations %}
+            <td>
+                <p class="attribute-value">{{ specifiedConsent.motivation(attribute) }}</p>
+            </td>
+            {% endif %}
         </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
This PR changes two things

1. The my services screen no longer breaks when attribute motivations are returned from the `read-arp` engine block API endpoint. This was fixed by making the response validation more tolerant. Now only the value entry is actively tested. The source and motivation are optional.
2. The motivation is displayed in the 'my services' overview.

The Pivotal story: https://www.pivotaltracker.com/story/show/158522286