### PR TITLE
Stop using SURFconextId as user identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ information via EngineBlock's internal API.
 - PHP 5.6
 - EngineBlock 5.6 >= 5.6.7 
 - EngineBlock 5.7 >= 5.7.1
+- EngineBlock must be configured to release an unspecified NameID to Profile
 
 ## Development
 To setup your development environment, run `vagrant up` in the project directory.

--- a/src/OpenConext/Profile/Tests/Entity/AuthenticatedUserTest.php
+++ b/src/OpenConext/Profile/Tests/Entity/AuthenticatedUserTest.php
@@ -114,10 +114,6 @@ class AuthenticatedUserTest extends TestCase
                 ['Chuck Tester']
             ),
             new Attribute(
-                new AttributeDefinition('Organization', 'urn:mace:surfconextid', 'urn:oid:1.3.6.1.4.1.1076.20.40.40.1'),
-                ['My Organization']
-            ),
-            new Attribute(
                 new AttributeDefinition('LDAP Directory string', '', 'urn:oid:1.3.6.1.4.1.1466.115.121.1.15'),
                 ['testers/chuck1']
             )

--- a/src/OpenConext/ProfileBundle/Resources/config/services.yml
+++ b/src/OpenConext/ProfileBundle/Resources/config/services.yml
@@ -261,9 +261,7 @@ services:
         public: false
         class: OpenConext\ProfileBundle\Service\ConsentService
         arguments:
-            - @logger
             - @openconext_eb_api.repository.consent
-            - @saml.attribute.surfconext.id
 
     profile.service.consent_listing:
         public: false

--- a/src/OpenConext/ProfileBundle/Service/ConsentService.php
+++ b/src/OpenConext/ProfileBundle/Service/ConsentService.php
@@ -27,28 +27,13 @@ use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 final class ConsentService
 {
     /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @var ConsentRepository
      */
     private $consentRepository;
 
-    /**
-     * @var AttributeDefinition
-     */
-    private $identifyingAttribute;
-
-    public function __construct(
-        LoggerInterface $logger,
-        ConsentRepository $consentRepository,
-        AttributeDefinition $identifyingAttribute
-    ) {
-        $this->logger               = $logger;
-        $this->consentRepository    = $consentRepository;
-        $this->identifyingAttribute = $identifyingAttribute;
+    public function __construct(ConsentRepository $consentRepository)
+    {
+        $this->consentRepository = $consentRepository;
     }
 
     /**
@@ -57,34 +42,6 @@ final class ConsentService
      */
     public function findAllFor(AuthenticatedUser $user)
     {
-        if (!$user->getAttributes()->containsAttributeDefinedBy($this->identifyingAttribute)) {
-            $message = sprintf(
-                'Cannot get consent list for user: user does not have identifying attribute "%s"',
-                $this->identifyingAttribute->getName()
-            );
-
-            $this->logger->error($message);
-
-            return null;
-        }
-
-        $userIdentifier    = $user->getAttributes()->getAttributeByDefinition($this->identifyingAttribute);
-        $identifyingValues = $userIdentifier->getValue();
-        $identifyingValue  = array_shift($identifyingValues);
-
-        if (!is_string($identifyingValue)) {
-            $message = sprintf(
-                'In order to get the consent list for a user, the identifying attribute must have a string value. "%s"'
-                . 'given for identifying attribute "%s"',
-                gettype($identifyingValue),
-                $this->identifyingAttribute->getName()
-            );
-
-            $this->logger->error($message);
-
-            return null;
-        }
-
-        return $this->consentRepository->findAllFor($identifyingValue);
+        return $this->consentRepository->findAllFor($user->getNameId());
     }
 }


### PR DESCRIPTION
The nameId value is now used instead. Containing the exact same value
as long as the NameID was configured to be unspecified (which it is in
our case).

The NameID can already be read from the AuthenticatedUser object, so
manually retrieving it from the assertion subject is not required.

The ConsentService could be cleaned up drastically.

https://www.pivotaltracker.com/story/show/164103691