### PR TITLE
Make locales configurable

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -4,9 +4,6 @@ imports:
     - { resource: services.yml }
     - { resource: global_view_parameters.yml }
 
-parameters:
-    locales: [en, nl, pt]
-
 framework:
     translator:      { fallback: [en] }
     secret:          "%secret%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,5 +1,7 @@
 parameters:
     secret: ThisTokenIsNotSoSecretChangeIt
+    # Available translation languages: en, nl, pt
+    locales: [en, nl]
     default_locale: en
     open_conext_locale_cookie_key: lang
     open_conext_locale_cookie_domain: .vm.openconext.org

--- a/src/OpenConext/Profile/Assert.php
+++ b/src/OpenConext/Profile/Assert.php
@@ -25,7 +25,16 @@ class Assert extends BaseAssertion
 {
     protected static $exceptionClass = 'OpenConext\Profile\Exception\AssertionFailedException';
 
-    public static function keysAre(array $array, array $expectedKeys, $propertyPath = null)
+    /**
+     * Verifies if the expected keys are in the array
+     *
+     * An exact match is not required.
+     *
+     * @param array $array
+     * @param array $expectedKeys
+     * @param null $propertyPath
+     */
+    public static function keysArePresent(array $array, array $expectedKeys, $propertyPath = null)
     {
         $givenKeys = array_keys($array);
 
@@ -36,39 +45,12 @@ class Assert extends BaseAssertion
             return;
         }
 
-        $givenCount = count($givenKeys);
-        $expectedCount = count($expectedKeys);
-
-        if ($givenCount < $expectedCount) {
-            $message = sprintf(
-                'Required keys "%s" are missing',
-                implode('", "', array_diff($expectedKeys, $givenKeys))
-            );
-        } elseif ($givenCount > $expectedCount) {
-            $message = sprintf(
-                'Additional keys "%s" found',
-                implode('", "', array_diff($givenKeys, $expectedKeys))
-            );
-        } else {
-            $additional = array_diff($givenKeys, $expectedKeys);
-            $required = array_diff($expectedKeys, $givenKeys);
-
-            $message = 'Keys do not match requirements';
-            if (!empty($additional)) {
-                $message .= sprintf(
-                    ', additional keys "%s" found',
-                    implode('", "', array_diff($givenKeys, $expectedKeys))
-                );
-            }
-
-            if (!empty($required)) {
-                $message .= sprintf(
-                    ', required keys "%s" are missing',
-                    implode('", "', array_diff($expectedKeys, $givenKeys))
-                );
+        foreach ($expectedKeys as $expectedKey) {
+            if (!in_array($expectedKey, $givenKeys)) {
+                $message = sprintf('Required key "%s" is missing', $expectedKey);
+                throw new AssertionFailedException($message, 0, $propertyPath, $array);
             }
         }
-
-        throw new AssertionFailedException($message, 0, $propertyPath, $array);
+        return;
     }
 }

--- a/src/OpenConext/Profile/Tests/AssertTest.php
+++ b/src/OpenConext/Profile/Tests/AssertTest.php
@@ -30,11 +30,11 @@ class AssertTest extends TestCase
      * @dataProvider missingKeysProvider
      *
      * @expectedException \OpenConext\Profile\Exception\AssertionFailedException
-     * @expectedExceptionMessage Required keys
+     * @expectedExceptionMessage Required key
      */
     public function missing_required_keys_trigger_an_exception($givenArray, $expectedKeys)
     {
-        Assert::keysAre($givenArray, $expectedKeys);
+        Assert::keysArePresent($givenArray, $expectedKeys);
     }
 
     public function missingKeysProvider()
@@ -43,47 +43,6 @@ class AssertTest extends TestCase
             'empty given array' => [[], ['MissingOne', 'MissingTwo']],
             'single missing key' => [['A' => 'a'], ['A', 'Missing']],
             'multiple missing keys' => [['A' => 'a'], ['A', 'MissingOne', 'MissingTwo']],
-        ];
-    }
-
-    /**
-     * @test
-     * @group Assert
-     * @dataProvider additionalKeysProvider
-     *
-     * @expectedException \OpenConext\Profile\Exception\AssertionFailedException
-     * @expectedExceptionMessage Additional keys
-     */
-    public function additional_keys_trigger_an_exception($givenArray, $expectedKeys)
-    {
-        Assert::keysAre($givenArray, $expectedKeys);
-    }
-
-    public function additionalKeysProvider()
-    {
-        return [
-            'empty expected keys' => [['AdditionalOne' => 'a', 'AdditionalTwo'=> 'b'], []],
-            'single additional key' => [['A' => 'a', 'Additional' => 'b'], ['A']],
-            'multiple additional keys' => [['A' => 'a', 'AdditionalOne' => 'b', 'AdditionalTwo' => 'c'], ['A']],
-        ];
-    }
-
-    /**
-     * @test
-     * @group Assert
-     * @dataProvider notMatchingKeysProvider
-     *
-     * @expectedException \OpenConext\Profile\Exception\AssertionFailedException
-     * @expectedExceptionMessage Keys do not match requirements
-     */
-    public function not_matching_keys_trigger_an_exception($givenArray, $expectedKeys)
-    {
-        Assert::keysAre($givenArray, $expectedKeys);
-    }
-
-    public function notMatchingKeysProvider()
-    {
-        return [
             'one key differs' => [['A' => 'a', 'B' => 'b'], ['A', 'C']],
             'two keys differ' => [['A' => 'a', 'B' => 'b'], ['C', 'D']]
         ];
@@ -94,12 +53,12 @@ class AssertTest extends TestCase
      * @group Assert
      * @dataProvider matchingKeysProvider
      */
-    public function matching_keys_do_not_trigger_an_exception($givenArray, $expectedKeys)
+    public function present_keys_do_not_trigger_an_exception($givenArray, $expectedKeys)
     {
         $exceptionIsThrown = false;
 
         try {
-            Assert::keysAre($givenArray, $expectedKeys);
+            Assert::keysArePresent($givenArray, $expectedKeys);
         } catch (AssertionFailedException $e) {
             $exceptionIsThrown = true;
         }
@@ -113,6 +72,9 @@ class AssertTest extends TestCase
             'empty array and no keys' => [[], []],
             'single key present in array' => [['A' => 'a'], ['A']],
             'multiple keys present in array' => [['A' => 'a', 'B' => 'b'], ['A', 'B']],
+            'empty expected keys' => [['AdditionalOne' => 'a', 'AdditionalTwo'=> 'b'], []],
+            'single additional key' => [['A' => 'a', 'Additional' => 'b'], ['A']],
+            'multiple additional keys' => [['A' => 'a', 'AdditionalOne' => 'b', 'AdditionalTwo' => 'c'], ['A']],
         ];
     }
 }

--- a/src/OpenConext/ProfileBundle/Service/GlobalViewParameters.php
+++ b/src/OpenConext/ProfileBundle/Service/GlobalViewParameters.php
@@ -71,11 +71,11 @@ final class GlobalViewParameters
         array $profileExplanationImageUrls,
         array $attributeInformationUrls
     ) {
-        Assert::keysAre($helpUrls, $locales);
-        Assert::keysAre($platformUrls, $locales);
-        Assert::keysAre($termsOfServiceUrls, $locales);
-        Assert::keysAre($profileExplanationImageUrls, $locales);
-        Assert::keysAre($attributeInformationUrls, $locales);
+        Assert::keysArePresent($helpUrls, $locales);
+        Assert::keysArePresent($platformUrls, $locales);
+        Assert::keysArePresent($termsOfServiceUrls, $locales);
+        Assert::keysArePresent($profileExplanationImageUrls, $locales);
+        Assert::keysArePresent($attributeInformationUrls, $locales);
 
         $this->translator                  = $translator;
         $this->helpUrls                    = $helpUrls;


### PR DESCRIPTION
The available locales must now be configured in the parameters.yml file. Previously we configured them in the main config file (in a parameters section). This change enables us to be more flexible in enabling/disabling languages. This would previously result in a VCS change.

The drawback of this is that we can enable/disable languages that might not be (fully) supported. This was previously more rigorously verified in the GlobalViewParameters VO.

