### PR TITLE
Test against PHP 7.2 and 7.3 with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: php
 
 php:
-  - 7.0
+  - 7.3
   - 5.6
 
 matrix:
   allow_failures:
-  - php: 7.0
+  - php: 7.3
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
 
 php:
-  - 7.3
   - 5.6
+  - 7.2
+  - 7.3
 
 matrix:
   allow_failures:
+  - php: 7.2
   - php: 7.3
 
 env:


### PR DESCRIPTION
This is done in order to be able to test behavior on PHP 7.2 & 7.3 to explore possible PHP migration issues.