### PR TITLE
Correctly capitalize alt text

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
@@ -24,7 +24,7 @@
                 <div class="mdl-grid">
                     <div class="mdl-cell mdl-cell--3-col">
                         <div class="mdl-layout-title">{{ 'profile.my_connections.service_label'|trans }}</div>
-                        <img src="{{ connection.logoPath }}" class="logo" title="{{ 'profile.my_connections.orcid.title'|trans }}" alt="ORCID iD logo" />
+                        <img src="{{ connection.logoPath }}" class="logo" title="{{ 'profile.my_connections.orcid.title'|trans }}" alt="ORCID ID logo" />
                     </div>
                     <div class="mdl-cell mdl-cell--3-col">
                         <div class="mdl-layout-title">{{ 'profile.my_connections.orcid.title'|trans }}</div>
@@ -64,7 +64,7 @@
                     <div class="mdl-grid">
                         <div class="mdl-cell mdl-cell--3-col">
                             <div class="mdl-layout-title">{{ 'profile.my_connections.service_label'|trans }}</div>
-                            <img src="{{ connection.logoPath }}" class="logo" title="{{ 'profile.my_connections.orcid.title'|trans }}" alt="ORCID iD logo" />
+                            <img src="{{ connection.logoPath }}" class="logo" title="{{ 'profile.my_connections.orcid.title'|trans }}" alt="ORCID ID logo" />
                         </div>
                         <div class="mdl-cell mdl-cell--6-col">
                             <div class="mdl-layout-title">{{ 'profile.my_connections.description_label'|trans }}</div>


### PR DESCRIPTION
ORCID ID logo instead of ORCID iD logo