### PR TITLE
Add /build to asset paths

### DIFF
--- a/app/config/global_view_parameters.yml.dist
+++ b/app/config/global_view_parameters.yml.dist
@@ -15,9 +15,9 @@ parameters:
         nl: "https://www.surfconext.nl"
         pt: "https://www.surfconext.nl/en"
     profile_explanation_image_path:
-        en: "/images/profile_home_en.png"
-        nl: "/images/profile_home_nl.png"
-        pt: "/images/profile_home_pt.png"
+        en: "build/images/profile_home_en.png"
+        nl: "build/images/profile_home_nl.png"
+        pt: "build/images/profile_home_pt.png"
     attribute_information_url:
         en: 'https://support.surfconext.nl/attributes-en'
         nl: 'https://support.surfconext.nl/attributes-nl'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -36,7 +36,7 @@ parameters:
     attribute_aggregation_api_verify_ssl: true
 
     # orcid aa attribute settings for orcid
-    attribute_aggregation_orcid_logo_path: '/images/orcid.png'
+    attribute_aggregation_orcid_logo_path: 'build/images/orcid.png'
     attribute_aggregation_orcid_connect_url: 'https://link.surfconext.nl/orcid?redirectUrl=https://profile.surfconext.nl/my-connections'
 
     mailer_transport:  sendmail

--- a/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
@@ -28,7 +28,7 @@
                     </div>
                     <div class="mdl-cell mdl-cell--3-col">
                         <div class="mdl-layout-title">{{ 'profile.my_connections.orcid.title'|trans }}</div>
-                        <p class="orcid"><img src="{{ asset('images/orcid_small.png') }}"> <a href="{{ connection.linkedId }}">{{ connection.linkedId }}</a></p>
+                        <p class="orcid"><img src="{{ asset('build/images/orcid_small.png') }}"> <a href="{{ connection.linkedId }}">{{ connection.linkedId }}</a></p>
                     </div>
                     <div class="mdl-cell mdl-cell--3-col">
                         <div class="mdl-layout-title">{{ 'profile.my_connections.orcid.status'|trans }}</div>


### PR DESCRIPTION
The asset paths where not set correctly, they needed to have the /build
prefix. This would prevent the images from loading correctly in prod
mode, but would work in development environments.