### PR TITLE
Optimize ORCiD button placement for all devices

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyConnections/overview.html.twig
@@ -62,20 +62,21 @@
 
                 <div class="attribute-container">
                     <div class="mdl-grid">
-                        <div class="mdl-cell mdl-cell--3-col">
-                            <div class="mdl-layout-title">{{ 'profile.my_connections.service_label'|trans }}</div>
-                            <img src="{{ asset(connection.logoPath) }}" class="logo" title="{{ 'profile.my_connections.orcid.title'|trans }}" alt="ORCID iD logo" />
-                        </div>
-                        <div class="mdl-cell mdl-cell--6-col">
-                            <div class="mdl-layout-title">{{ 'profile.my_connections.description_label'|trans }}</div>
-                            <p>{{ 'profile.my_connections.orcid.description'|trans|nl2br }}</p>
-                        </div>
-                        <div class="mdl-cell mdl-cell--3-col">
+                        <div class="mdl-cell mdl-cell--12-col">
                             <a
                                     class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored orcid"
                                     href="{{ connection.connectUrl }}">
                                 {{ 'profile.my_connections.orcid.connect_title'|trans }}
                             </a>
+                        </div>
+
+                        <div class="mdl-cell mdl-cell--3-col">
+                            <div class="mdl-layout-title">{{ 'profile.my_connections.service_label'|trans }}</div>
+                            <img src="{{ asset(connection.logoPath) }}" class="logo" title="{{ 'profile.my_connections.orcid.title'|trans }}" alt="ORCID iD logo" />
+                        </div>
+                        <div class="mdl-cell mdl-cell--9-col">
+                            <div class="mdl-layout-title">{{ 'profile.my_connections.description_label'|trans }}</div>
+                            <p>{{ 'profile.my_connections.orcid.description'|trans|nl2br }}</p>
                         </div>
                     </div>
                 </div>

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -309,13 +309,10 @@ tr.service:hover {
 .attribute-container .mdl-grid .mdl-cell img.logo {
     border: 1px solid #cccccc;
     background: #ffffff;
-    width: 200px;
     float: left;
-    padding: 10px;
-    margin: 10px 0 10px 0;
-    max-width: 100%;
-    height: auto;
-    display: block;
+    margin: 0;
+    width: auto;
+    display: inline-block;
 }
 
 .attribute-container .mdl-grid .mdl-cell p.orcid {
@@ -334,9 +331,11 @@ tr.service:hover {
 }
 
 .attribute-container .mdl-grid .mdl-cell a.mdl-button {
+    box-sizing: border-box;
     display: block;
-    width: 260px;
-    margin: 40px auto;
+    max-width: 260px;
+    margin-top: 20px;
+    padding-left: 40px;
     text-align: right;
     text-decoration: none;
 }
@@ -465,5 +464,13 @@ a.download:before {
     /* Content container */
     .mdl-layout__content .content-container .introduction-explanation-image {
         max-width: 704px;
+    }
+}
+
+@media (max-width: 400px) {
+
+    /* orcid button */
+    .mdl-button.orcid {
+        font-size: 9px;
     }
 }


### PR DESCRIPTION
The login button doesn't fit on small screens even if they aren't that
small. Now the button is placed above the connection so it will fit.