### PR TITLE
Upgrade xmlseclibs to version 3.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ branches:
   only:
     - master
     - develop
+    - /^hotfix\/(.*)$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,8 @@ branches:
     - master
     - develop
     - /^hotfix\/(.*)$/
+
+addons:
+  apt:
+    packages:
+      - ant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Next release
 
+# 1.2.3
+This is a security release that will harden the application against CVE 2019-3465
+* Upgrade xmlseclibs to version 3.0.4 #138
+
+
 # 1.2.2
 
 Further removes the SURFconextId usages in the project. The AA Api client still used the attribute, causing issues on the My connections page. Thanks @domgon for raising the issue!

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,13 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache"
         ]
     },
+    "config": {
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "5.6"
+        },
+        "sort-packages": true
+    },
     "extra": {
         "symfony-app-dir": "app",
         "symfony-web-dir": "web",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64466e62daf84fe90d527403b8b572ba",
+    "content-hash": "8c8eb3decea9cdcd7dde10ad0f9e41c7",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1521,16 +1521,16 @@
         },
         {
             "name": "robrichards/xmlseclibs",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robrichards/xmlseclibs.git",
-                "reference": "406c68ac9124db033d079284b719958b829cb830"
+                "reference": "0a53d3c3aa87564910cae4ed01416441d3ae0db5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/406c68ac9124db033d079284b719958b829cb830",
-                "reference": "406c68ac9124db033d079284b719958b829cb830",
+                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/0a53d3c3aa87564910cae4ed01416441d3ae0db5",
+                "reference": "0a53d3c3aa87564910cae4ed01416441d3ae0db5",
                 "shasum": ""
             },
             "require": {
@@ -1555,7 +1555,7 @@
                 "xml",
                 "xmldsig"
             ],
-            "time": "2018-11-15T11:59:02+00:00"
+            "time": "2019-11-05T11:44:22+00:00"
         },
         {
             "name": "sensio/distribution-bundle",
@@ -4257,5 +4257,8 @@
     "platform": {
         "php": ">=5.6,<7"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6"
+    }
 }


### PR DESCRIPTION
This change will apply the countermeasures to harden against
CVE 2019-3465 and will effectively bump `robrichards/xmlseclibs` to
version 3.0.4.