### PR TITLE
Remove support for filtering on EB entity ID

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -129,7 +129,6 @@ open_conext_attribute_aggregation_api_client:
         verify_ssl: '%attribute_aggregation_api_verify_ssl%'
 
 open_conext_profile:
-    engine_block_entity_id: '%saml_remote_idp_entity_id%'
     locales: '%locales%'
     default_locale: '%default_locale%'
     locale_cookie_domain: '%open_conext_locale_cookie_domain%'

--- a/src/OpenConext/ProfileBundle/DependencyInjection/OpenConextProfileExtension.php
+++ b/src/OpenConext/ProfileBundle/DependencyInjection/OpenConextProfileExtension.php
@@ -39,9 +39,7 @@ class OpenConextProfileExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
-
-        $this->parseEngineBlockEntityIdConfiguration($config['engine_block_entity_id'], $container);
-
+        
         $this->parseAttributeSupportMailConfiguration($config['attribute_support'], $container);
         $this->parseInformationRequestMailConfiguration($config['information_request'], $container);
 
@@ -66,13 +64,6 @@ class OpenConextProfileExtension extends Extension
             $container->getDefinition(UserService::class)
                 ->removeMethodCall('setUserLifecycleApiClient');
         }
-    }
-
-    private function parseEngineBlockEntityIdConfiguration($engineBlockEntityId, ContainerBuilder $container)
-    {
-        $container
-            ->getDefinition('OpenConext\Profile\Value\EntityId')
-            ->replaceArgument(0, $engineBlockEntityId);
     }
 
     private function parseAttributeSupportMailConfiguration(array $attributeSupportConfig, ContainerBuilder $container)


### PR DESCRIPTION
Prior to this change, the filtering was needed for the generic "these entity ids should be filtered problem".  Given that the special cased entity has been removed from EB, this is no longer needed.

This change removes the filtering.

Pivotal ticket @ https://www.pivotaltracker.com/story/show/111038134