### PR TITLE
Add delete modal for my connections

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -9,6 +9,10 @@ accessibility:
 
     skip_link: 'To main content'
 
+general:
+    cancel: Cancel
+    confirm: Confirm
+
 profile:
     application:
         platform_connection_name: SURFconext
@@ -24,10 +28,6 @@ profile:
         explanation: 'The mail with your information has been successfully sent.'
         long_title: 'Attribute data has been mailed'
         short_title: 'Attribute data mailed'
-
-    confirm_connection_delete:
-        confirm: Confirm
-        confirm_label: 'I agree to disconnect this connection.'
 
     error:
         403:
@@ -79,6 +79,12 @@ profile:
     my_connections:
         active_connections: 'Active connections'
         available_connections: 'Available Connections'
+
+        delete_connection:
+            explanation: 'Are you sure you want to delete your unique pseudonymised eduId for ORCID and revoke access to your linked accounts?'
+            title: 'Delete Service'
+            warning: 'This service might not recognize you the next time you login and all your personal data within this service might be lost.'
+
         explanation: 'It''s possible to connect external sources to your SURFconext profile. SURFconext can use this information to enrich the existing attributes of your institutional account with the values from this external account. Services connected to SURFconext can receive and use this information.'
         long_title: 'Accounts linked to your profile'
         missing_connections: 'Missing Connections?'

--- a/app/Resources/translations/messages.nl.yml
+++ b/app/Resources/translations/messages.nl.yml
@@ -5,9 +5,13 @@ accessibility:
 
     nav:
         mobile_expand: 'Hoofdnavigatie openen'
-        title: 'Hoofdnavigatie'
+        title: Hoofdnavigatie
 
     skip_link: 'Naar de hoofdinhoud'
+
+general:
+    cancel: 'Annuleren'
+    confirm: 'Bevestigen'
 
 profile:
     application:
@@ -24,10 +28,6 @@ profile:
         explanation: 'De mail met informatie is succesvol verstuurd.'
         long_title: 'De attribuutdata is gemaild'
         short_title: 'Attribuutdata gemaild'
-
-    confirm_connection_delete:
-        confirm: Toepassen
-        confirm_label: 'Ja, verwijder deze koppeling'
 
     error:
         403:
@@ -79,6 +79,12 @@ profile:
     my_connections:
         active_connections: 'Actieve koppelingen'
         available_connections: 'Beschikbare koppelingen'
+
+        delete_connection:
+            explanation: 'Ben je zeker dat je jouw unieke gepseudonimiseerde eduId voor ORCID wil verwijderen en de toegang tot je gelinkte accounts wil herroepen?'
+            title: 'Dienst verwijderen'
+            warning: 'Deze dienst zal je misschien niet meer herkennen de volgende keer je inlogt, waardoor al je persoonlijke data kan verloren zijn.'
+
         explanation: 'Je kunt externe bronnen koppelen aan je SURFconext-profiel. SURFconext kan deze gegevens gebruiken om je bestaande attributen afkomstig van je instellingsaccount te verrijken met de waarden uit het gekoppelde account. Diensten die verbonden zijn met SURFconext kunnen vervolgens deze informatie ontvangen.'
         long_title: 'Accounts gelinkt aan je profiel'
         missing_connections: 'Missende koppelingen?'
@@ -150,7 +156,7 @@ profile:
         short_title: 'Mijn diensten'
         supportEmail: 'E-mailadres support'
         support_title: Support
-        support_url: "Support pagina's"
+        support_url: 'Support pagina''s'
 
     my_surf_conext:
         account_data: Accountgegevens

--- a/app/Resources/translations/messages.pt.yml
+++ b/app/Resources/translations/messages.pt.yml
@@ -9,6 +9,10 @@ accessibility:
 
     skip_link: 'Para o conteúdo principal'
 
+general:
+    cancel: Cancel # FIXME
+    confirm: Confirm # FIXME
+
 profile:
     application:
         platform_connection_name: SURFconext
@@ -24,10 +28,6 @@ profile:
         explanation: 'O email com os seus dados foi enviado com sucesso.'
         long_title: 'Os atributos foram enviados por email'
         short_title: 'Atributo enviado por email'
-
-    confirm_connection_delete:
-        confirm: Confirmar
-        confirm_label: 'Concordo com o desligar desta ligação.'
 
     error:
         403:
@@ -79,6 +79,12 @@ profile:
     my_connections:
         active_connections: 'Ligações activas'
         available_connections: 'Ligações disponíveis'
+
+        delete_connection:
+            explanation: 'Are you sure you want to delete your unique pseudonymised eduId for ORCID and revoke access to your linked accounts?' # FIXME
+            title: 'Delete Service' # FIXME
+            warning: 'This service might not recognize you the next time you login and all your personal data within this service might be lost.' # FIXME
+
         explanation: 'É possível ligar fontes externas ao seu Perfil SURFconext. A SURFconext consegue usar esta informação para enriquecer os atributos existentes da sua conta institucional com os valores desta conta externa. Os serviços ligados à SURFconext podem receber e usar esta informação.'
         long_title: 'Contas ligadas ao seu perfil'
         missing_connections: 'Ligações em falta?'

--- a/app/web/css/components/components.scss
+++ b/app/web/css/components/components.scss
@@ -6,5 +6,6 @@
 @import 'list';
 @import 'locale-switch';
 @import 'modal';
+@import 'modal-window';
 @import 'note';
 @import 'tooltip';

--- a/app/web/css/components/modal-window.scss
+++ b/app/web/css/components/modal-window.scss
@@ -1,0 +1,68 @@
+@import '../helpers/helpers';
+
+.modalWindow[role="alertdialog"] {
+  background: rgba(0,0,0,0.2);
+  bottom: 0;
+  left: 0;
+  opacity:0;
+  pointer-events: none;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 99999;
+
+  &:target {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.modalWindow__content {
+  background: $white;
+  border-radius: 8px;
+  color: $black;
+  font-size: $f-large;
+  line-height: 1.33;
+  margin: 15% auto;
+  max-width: 90%;
+  position: relative;
+  width: calculateRem(528px);
+
+  p {
+    margin-top: 0;
+  }
+}
+
+.modalWindow__header {
+  @include border-top-radius(8px);
+  @include focus();
+  background: $providerGray;
+  font-size: $f-h5;
+  font-weight: $normal;
+  height: calculateRem(60px);
+  letter-spacing: -0.11px;
+  line-height: 1.3;
+  margin: 0;
+  padding: calculateRem(18px) calculateRem(32px) 1rem;
+}
+
+.modalWindow__main {
+  padding: calculateRem(18px) calculateRem(32px) 1rem;
+}
+
+.modalWindow__buttonRow {
+  display: flex;
+  justify-content: space-between;
+  margin-top: calculateRem(45px);
+}
+
+.modalWindow__button {
+  height: 3rem;
+  padding-bottom: 1rem;
+  padding-top: 1rem;
+  width: calc((100% - 1.5rem) / 2);
+
+  &--form {
+    width: 100%;
+  }
+}

--- a/app/web/css/helpers/mixins.scss
+++ b/app/web/css/helpers/mixins.scss
@@ -131,6 +131,11 @@
     border-bottom-left-radius: $value;
 }
 
+@mixin border-top-radius($value) {
+    border-top-right-radius: $value;
+    border-top-left-radius: $value;
+}
+
 @mixin font-style-large {
     font-size: $f-large;
     font-weight: $bolder;

--- a/app/web/css/main.scss
+++ b/app/web/css/main.scss
@@ -34,22 +34,3 @@
 [data-service-details-state="closed"] .service-details {
     display: none;
 }
-
-.confirmation-container {
-    display: none;
-}
-
-.confirmation-container div {
-    clear: both;
-}
-
-.confirmation-container input.confirmation {
-    float: left;
-}
-.confirmation-container label.confirmation-label {
-    margin-left: 5px;
-    font-weight: 500;
-}
-.confirmation-container button.mdl-button {
-    margin-top: 10px;
-}

--- a/app/web/css/pages/myConnections/myConnections.scss
+++ b/app/web/css/pages/myConnections/myConnections.scss
@@ -7,3 +7,8 @@
 .connection__buttonWrapper {
   margin-top: 2rem;
 }
+
+.connection__deleteForm {
+  margin-left: 1.5rem;
+  width: calc((100% - 1.5rem) / 2);
+}

--- a/app/web/js/app.js
+++ b/app/web/js/app.js
@@ -2,5 +2,6 @@ require('jquery');
 require('./dialog.js');
 require('./main.js');
 require('./mobileMenu.js');
+require('./modalWindow.js');
 require('./tooltip.js');
 require('../css/application.scss');

--- a/app/web/js/modalWindow.js
+++ b/app/web/js/modalWindow.js
@@ -1,0 +1,69 @@
+$(function () {
+    $('.disconnect').on('click', function (e) {
+        const id = $(e.target).data('id');
+        const modal = document.getElementById(id);
+        addModalTrap(modal);
+
+        setTimeout(() => {
+            const cancel = modal.querySelector('.modalWindow__cancel');
+            cancel.focus({preventScroll: true});
+        }, 200);
+    });
+
+    $('.modalWindow__cancel').on('click', function (e) {
+        const id = $(e.target).data('to');
+        const modal = document.getElementById(id);
+
+        setTimeout(() => {
+            const button = document.querySelector(`a[data-id="${id}"]`);
+            button.focus({preventScroll: true});
+            modal.removeEventListener('keydown', modalTrap);
+        }, 200);
+    });
+
+});
+function addModalTrap(modal)
+{
+    const focusableElements =
+      'button:not([type="hidden"]), [href]:not([type="hidden"]), input:not([type="hidden"]), select:not([type="hidden"]), textarea:not([type="hidden"]), [tabindex]:not([tabindex="-1"]):not([type="hidden"])';
+    const focusableContent = modal.querySelectorAll(focusableElements);
+    const firstFocusableElement = focusableContent[0]; // get first element to be focused inside modal
+
+    modal.addEventListener('keydown', modalTrap);
+
+    firstFocusableElement.focus();
+}
+
+function modalTrap(e)
+{
+    let isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+    let isEscPressed = e.key === 'Escape' || e.keyCode === 27;
+    const focusableElements =
+      'button:not([type="hidden"]), [href]:not([type="hidden"]), input:not([type="hidden"]), select:not([type="hidden"]), textarea:not([type="hidden"]), [tabindex]:not([tabindex="-1"]):not([type="hidden"])';
+    const focusableContent = this.querySelectorAll(focusableElements);
+    const firstFocusableElement = focusableContent[0]; // get first element to be focused inside modal
+    const lastFocusableElement = focusableContent[focusableContent.length - 1]; // get last element to be focused inside modal
+
+    if (isEscPressed) {
+        const cancelButton = this.querySelector('.modalWindow__cancel');
+        const clickEvent = new MouseEvent('click');
+        cancelButton.dispatchEvent(clickEvent);
+        return;
+    }
+
+    if (!isTabPressed) {
+        return;
+    }
+
+    if (e.shiftKey) { // if shift key pressed for shift + tab combination
+        if (document.activeElement === firstFocusableElement) {
+            lastFocusableElement.focus(); // add focus for the last focusable element
+            e.preventDefault();
+        }
+    } else { // if tab key is pressed
+        if (document.activeElement === lastFocusableElement) { // if focused has reached to last focusable element then focus first focusable element after pressing tab
+            firstFocusableElement.focus(); // add focus for the first focusable element
+            e.preventDefault();
+        }
+    }
+}

--- a/app/web/js/my-connections.js
+++ b/app/web/js/my-connections.js
@@ -1,11 +1,11 @@
-$(document).on('click', 'button.disconnect', function (e) {
-    var button = $(e.target),
-        form = $('form.confirmation-container');
-
-    button.hide(200, function(){
-        form.show(200);
-    });
-});
+// $(document).on('click', '.disconnect', function (e) {
+//     var button = $(e.target),
+//         form = $('form.confirmation-container');
+//
+//     button.hide(200, function(){
+//         form.show(200);
+//     });
+// });
 
 $(document).on('change', 'input.confirmation', function(e) {
     var checkbox = $(e.target),

--- a/src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php
+++ b/src/OpenConext/ProfileBundle/Form/Type/ConfirmConnectionDeleteType.php
@@ -19,7 +19,6 @@
 namespace OpenConext\ProfileBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -30,26 +29,13 @@ class ConfirmConnectionDeleteType extends AbstractType
     {
         $builder
             ->add(
-                'confirmed',
-                CheckboxType::class,
-                [
-                    'attr' => ['class' => 'mdl-checkbox__input confirmation'],
-                    'label' => 'profile.confirm_connection_delete.confirm_label',
-                    'label_attr' => ['class' => 'confirmation-label'],
-                    'empty_data' => false,
-                    'required' => true,
-                ]
-            )
-            ->add(
                 'confirm-button',
                 SubmitType::class,
                 [
                     'attr' => [
-                        'class' => 'mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect ' .
-                                   'mdl-button--accent confirm-button',
-                        'disabled' => 'disabled',
+                        'class' => 'button modalWindow__button modalWindow__button--form',
                     ],
-                    'label' => 'profile.confirm_connection_delete.confirm',
+                    'label' => 'general.confirm',
                 ]
             );
     }

--- a/src/OpenConext/ProfileBundle/Resources/views/MyConnections/active-connections.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyConnections/active-connections.html.twig
@@ -20,15 +20,37 @@
                                     {{ connection.linkedId }}
                                 </a>
                             </p>
-                            <div class="connection__buttonWrapper">
-                                <button class="button__secondary--white disconnect">
-                                    {{ 'profile.my_connections.orcid.disconnect_title'|trans }}
-                                </button>
+                            {% set linkId = 'delete_active_' ~ loop.index %}
+                            <a class="button__secondary--white disconnect" data-id={{ linkId }} href="#{{ linkId }}">
+                                {{ 'profile.my_connections.orcid.disconnect_title'|trans }}
+                            </a>
 
-                                {{ form_start(confirmForm, {attr: {'class': 'confirmation-container', 'novalidate': 'novalidate'} }) }}
-                                {{ form_widget(confirmForm) }}
-                                {{ form_end(confirmForm) }}
-                            </div>
+                            {% set headerId = 'dialog-header-' ~ loop.index %}
+                            <div
+                                class="modalWindow"
+                                id="{{ linkId }}"
+                                role="alertdialog"
+                                aria-modal="true"
+                                aria-labelledby="{{ headerId }}"
+                                aria-describedby="description-part-1-{{ loop.index }} description-part-2-{{ loop.index }}"
+                            >
+                                    <div class="modalWindow__content">
+                                        <h4
+                                            class="modalWindow__header"
+                                            id={{ headerId }}
+                                        >{{ 'profile.my_connections.delete_connection.title'|trans }}</h4>
+                                        <div class="modalWindow__main">
+                                            <p id="description-part-1-{{ loop.index }}">{{ 'profile.my_connections.delete_connection.explanation'|trans }}</p>
+                                            <p id="description-part-2-{{ loop.index }}">{{ 'profile.my_connections.delete_connection.warning'|trans }}</p>
+                                            <div class="modalWindow__buttonRow">
+                                                <a href="#ok" class="button button__secondary--white modalWindow__button modalWindow__cancel"  data-to={{ linkId }}>{{ 'general.cancel'|trans }}</a>
+                                                {{ form_start(confirmForm, {attr: { class: "connection__deleteForm", 'novalidate': 'novalidate'} }) }}
+                                                {{ form_widget(confirmForm) }}
+                                                {{ form_end(confirmForm) }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                         </div>
                     </details>
                 </li>


### PR DESCRIPTION
Prior to this change, the old layout was still used.  The new design calls for a modal.

This change ensures the modal with the propper design is used.  It also ensures the modal is fully accessible.

The modal technique was taken from this example: https://tutorialspage.com/create-modal-window-pure-html5-css3/
The modal trap was modified from code found on: https://uxdesign.cc/how-to-trap-focus-inside-modal-to-make-it-ada-compliant-6a50f9a70700