### PR TITLE
Deprecation resolutions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5924,21 +5924,21 @@
     "packages-dev": [
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
                 "phpstan/phpstan": "^0.12.55",
@@ -5965,11 +5965,6 @@
                 "Xdebug",
                 "performance"
             ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
-            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -5984,7 +5979,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-05T19:37:51+00:00"
+            "time": "2021-07-31T17:03:58+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -7627,6 +7622,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "abandoned": true,
             "time": "2015-07-28T20:34:47+00:00"
         },
         {

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -11,7 +11,6 @@ security:
     default:
       pattern: ^/authentication/metadata$
       anonymous: ~
-      logout_on_user_change: true
 
     monitor:
       pattern: ^/(info|health)$
@@ -19,7 +18,6 @@ security:
 
     saml_based:
       saml: true
-      logout_on_user_change: true
 
   access_control:
     - { path: ^/authentication, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }

--- a/src/OpenConext/AttributeAggregationApiClientBundle/DependencyInjection/Configuration.php
+++ b/src/OpenConext/AttributeAggregationApiClientBundle/DependencyInjection/Configuration.php
@@ -25,8 +25,8 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('open_conext_attribute_aggregation');
+        $treeBuilder = new TreeBuilder('open_conext_attribute_aggregation');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/OpenConext/EngineBlockApiClientBundle/DependencyInjection/Configuration.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/DependencyInjection/Configuration.php
@@ -25,8 +25,8 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('open_conext_engine_block_api_client');
+        $treeBuilder = new TreeBuilder('open_conext_engine_block_api_client');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/OpenConext/ProfileBundle/DependencyInjection/Configuration.php
+++ b/src/OpenConext/ProfileBundle/DependencyInjection/Configuration.php
@@ -27,8 +27,8 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('open_conext_profile');
+        $treeBuilder = new TreeBuilder('open_conext_profile');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/OpenConext/ProfileBundle/Resources/config/routing.yml
+++ b/src/OpenConext/ProfileBundle/Resources/config/routing.yml
@@ -3,111 +3,111 @@ profile.introduction_overview:
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:Introduction:overview
+        _controller: OpenConext\ProfileBundle\Controller\IntroductionController::overviewAction
 
 profile.my_profile_overview:
     path:       /my-profile
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:MyProfile:overview
+        _controller: OpenConext\ProfileBundle\Controller\MyProfileController::overviewAction
 
 profile.my_surf_conext_overview:
     path:       /my-surfconext
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:MySurfConext:overview
+        _controller: OpenConext\ProfileBundle\Controller\MySurfConextController::overviewAction
 
 profile.my_surf_conext_user_data_download:
     path:       /my-surfconext/download
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:MySurfConext:userDataDownload
+        _controller: OpenConext\ProfileBundle\Controller\MySurfConextController::userDataDownloadAction
 
 profile.my_services_overview:
     path:       /my-services
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:MyServices:overview
+        _controller: OpenConext\ProfileBundle\Controller\MyServicesController::overviewAction
 
 profile.my_services_delete:
     path:       /my-services/delete/{id}
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:MyServices:delete
+        _controller: OpenConext\ProfileBundle\Controller\MyServicesController::deleteAction
 
 profile.my_connections_overview:
     path:       /my-connections
     methods:    [GET,POST]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:MyConnections:overview
+        _controller: OpenConext\ProfileBundle\Controller\MyConnectionsController::overviewAction
 
 profile.saml_consume_assertion:
     path:       /authentication/consume-assertion
     methods:    [POST]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:Saml:consumeAssertion
+        _controller: OpenConext\ProfileBundle\Controller\SamlController::consumeAssertionAction
 
 profile.saml_metadata:
     path:       /authentication/metadata
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:Saml:metadata
+        _controller: OpenConext\ProfileBundle\Controller\SamlController::metadataAction
 
 profile.attribute_support_overview:
     path:       /attribute-support
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:AttributeSupport:overview
+        _controller: OpenConext\ProfileBundle\Controller\AttributeSupportController::overviewAction
 
 profile.attribute_support_confirm_mail_sent:
     path:       /attribute-support/confirmation
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:AttributeSupport:confirmMailSent
+        _controller: OpenConext\ProfileBundle\Controller\AttributeSupportController::confirmMailSentAction
 
 profile.attribute_support_send_mail:
     path:       /attribute-support/send-mail
     methods:    [POST]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:AttributeSupport:sendMail
+        _controller: OpenConext\ProfileBundle\Controller\AttributeSupportController::sendMailAction
 
 profile.information_request_overview:
     path:       /information-request
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:InformationRequest:overview
+        _controller: OpenConext\ProfileBundle\Controller\InformationRequestController::overviewAction
 
 profile.information_request_confirm_mail_sent:
     path:       /information-request/confirmation
     methods:    [GET]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:InformationRequest:confirmMailSent
+        _controller: OpenConext\ProfileBundle\Controller\InformationRequestController::confirmMailSentAction
 
 profile.information_request_send_mail:
     path:       /information-request/send-mail
     methods:    [POST]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:InformationRequest:sendMail
+        _controller: OpenConext\ProfileBundle\Controller\InformationRequestController::sendMailAction
 
 profile.locale_switch_locale:
     path:       /switch-locale
     methods:    [POST]
     schemes:    https
     defaults:
-        _controller: OpenConextProfileBundle:Locale:switchLocale
+        _controller: OpenConext\ProfileBundle\Controller\LocaleController::switchLocaleAction
     requirements:
         'return-url': '.+'

--- a/src/OpenConext/ProfileBundle/Resources/views/MySurfConext/data-download.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MySurfConext/data-download.html.twig
@@ -3,7 +3,7 @@
     <div class="mySurfConext__downloadExplanation">
         <p class="mySurfConext__downloadText">{{ 'profile.my_profile.user_data_download.explanation'|trans }}</p>
         <div class="mySurfConext__downloadButtonWrapper">
-            <a href="{{ 'profile.my_profile.user_data_download.link|trans' }}" class="button mySurfConext__downloadButton">{{ 'profile.my_profile.user_data_download.link_text'|trans }}</a>
+            <a href="{{ url('profile.my_surf_conext_user_data_download') }}" class="button mySurfConext__downloadButton">{{ 'profile.my_profile.user_data_download.link_text'|trans }}</a>
         </div>
     </div>
 </section>

--- a/src/OpenConext/ProfileBundle/Security/Firewall/SamlListener.php
+++ b/src/OpenConext/ProfileBundle/Security/Firewall/SamlListener.php
@@ -37,7 +37,8 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
-use Twig_Environment as Twig;
+use Twig\Environment;
+use Twig\Environment as Twig;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -80,7 +81,7 @@ class SamlListener implements ListenerInterface
     private $stateHandler;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 

--- a/src/OpenConext/ProfileBundle/Twig/LocaleExtension.php
+++ b/src/OpenConext/ProfileBundle/Twig/LocaleExtension.php
@@ -21,8 +21,8 @@ namespace OpenConext\ProfileBundle\Twig;
 use OpenConext\Profile\Assert;
 use OpenConext\ProfileBundle\Form\Type\SwitchLocaleType;
 use Symfony\Component\Form\FormFactoryInterface;
-use Twig_Extension as Extension;
-use Twig_SimpleFunction as SimpleFunction;
+use Twig\Extension\AbstractExtension as Extension;
+use Twig\TwigFunction as SimpleFunction;
 
 final class LocaleExtension extends Extension
 {

--- a/src/OpenConext/UserLifecycleApiClientBundle/DependencyInjection/Configuration.php
+++ b/src/OpenConext/UserLifecycleApiClientBundle/DependencyInjection/Configuration.php
@@ -25,8 +25,8 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('open_conext_user_lifecycle_api_client');
+        $treeBuilder = new TreeBuilder('open_conext_user_lifecycle_api_client');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
Remove as many deprecation warnings as humanly possible. A large amount of warnings are left in place as they are generated by the Stepup-bundle