### PR TITLE
Ensure login details is on one row

### DIFF
--- a/assets/css/pages/myServices/loginDetails.scss
+++ b/assets/css/pages/myServices/loginDetails.scss
@@ -10,7 +10,7 @@
     color: $black;
     font-weight: $normal;
     line-height: calculateRem(31px);
-    width: 25%;
+    width: 33%;
   }
 
   dd {
@@ -19,11 +19,15 @@
     line-height: calculateRem(31px);
     margin: 0;
     padding-left: 1rem;
-    width: 75%;
+    width: 67%;
   }
 
   @include screen('mobile') {
     flex-direction: column;
+
+    dd {
+      padding-left: 0;
+    }
 
     dt,
     dd {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
+        <meta content="initial-scale=1.0,width=device-width" name="viewport">
         <title>{% block title %}Welcome!{% endblock %}</title>
         {# Run `composer require symfony/webpack-encore-bundle`
            and uncomment the following Encore helpers to start using Symfony UX #}


### PR DESCRIPTION
Prior to this change, there was a regression in the styling of login-details.  The label received too little space, meaning it was split over two rows.

This change ensures the label is fully on one row again.