### PR TITLE
Apply correct role to modal triggering button

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/views/helpers/modal.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/helpers/modal.html.twig
@@ -4,7 +4,13 @@
 {% endif %}
 {% set headerId = 'dialog-header-' ~ loop.index %}
 
-<a class="button__secondary--white {{ buttonClass }}" data-id={{ linkId }} href="#{{ linkId }}"{% if buttonDescription is defined %} aria-describedBy="{{ buttonDescription }}"{% endif %}>
+<a
+    class="button__secondary--white {{ buttonClass }}"
+    data-id="{{ linkId }}"
+    href="#{{ linkId }}"
+    role="button"
+    {% if buttonDescription is defined %} aria-describedBy="{{ buttonDescription }}"{% endif %}
+>
     {{ buttonText }}
 </a>
 


### PR DESCRIPTION
Prior to this change, the element triggering a modal did not have the correct role.  This lead to a somewhat weird announcement in a screenreader.

This change ensures the right role is added.