### PR TITLE
Ensure givenName is not required for using Profile

### DIFF
--- a/src/OpenConext/ProfileBundle/Controller/IntroductionController.php
+++ b/src/OpenConext/ProfileBundle/Controller/IntroductionController.php
@@ -86,7 +86,7 @@ class IntroductionController
                 ->getValue()[0];
         } catch (RuntimeException $e) {
             $this->logger->info("Unable to retrieve the givenName attribute. It is not present in the attribute set");
-            $userName = '';
+            $userName = false;
         }
         return new Response($this->templateEngine->render('@OpenConextProfile/Introduction/overview.html.twig', [
             'userName' => $userName,

--- a/src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/Introduction/overview.html.twig
@@ -9,8 +9,11 @@
 {% endblock %}
 
 {% block content %}
+    {% if userName %}
     <h1 class="content__title">{{ 'profile.introduction.long_title'|trans({ '%userName%': userName }) }}</h1>
-
+    {% else %}
+        <h1 class="content__title">{{ 'profile.introduction.long_title'|trans({ '%userName%': 'profile.introduction.long_title_user_name_replacement'|trans }) }}</h1>
+    {% endif %}
     <p>{{ 'profile.introduction.explanation.introduction.start'|trans }} <strong>{{ 'profile.introduction.explanation.introduction.serviceName'|trans }}</strong> {{ 'profile.introduction.explanation.introduction.end'|trans }}</p>
 
     {% include "@OpenConextProfile/Introduction/navigation-cards.html.twig" %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -67,6 +67,7 @@ profile:
                 start: With
 
         long_title: 'Hi %userName%!'
+        long_title_user_name_replacement: 'there'
 
         purpose:
             profile_storage: "On behalf of your institution, SURFconext forwards a limited amount of your personal data to the service you are logging in to. Most of the times you are required to give explicit consent for this information transfer. In some cases, however, this feature is disabled on request of your institution.\n\nThis profile page gives you insight in which personal data, provided by your institution via SURFconext, has been forwarded to which service. You can also review which personal data is being stored by SURFconext and which services you have logged in to in the past."

--- a/translations/messages.nl.yml
+++ b/translations/messages.nl.yml
@@ -66,7 +66,8 @@ profile:
                 serviceName: SURFconext
                 start: Met
 
-        long_title: 'De profielpagina van SURFconext'
+        long_title: 'Hallo %userName%!'
+        long_title_user_name_replacement: 'daar'
 
         purpose:
             profile_storage: "Op verzoek van jouw instelling geeft SURFconext een beperkt aantal persoonsgegevens door aan de dienst waar je inlogt. Soms gaat dit automatisch bij het inloggen, in andere gevallen moet jij vooraf expliciet toestemming geven voor de doorgave van jouw gegevens.\n\nDeze profielpagina geeft je inzicht in welke persoonlijke data, afkomstig van jouw instelling, via SURFconext aan welke dienst wordt doorgegeven. Ook kun je zien welke gegevens door SURFconext worden opgeslagen en bij welke diensten je in het verleden bent ingelogd via SURFconext."

--- a/translations/messages.pt.yml
+++ b/translations/messages.pt.yml
@@ -67,6 +67,7 @@ profile:
                 start: Com
 
         long_title: 'Página do perfil da SURFconext'
+        long_title_user_name_replacement: ''
 
         purpose:
             profile_storage: "Em nome da sua instituição, a SURFconext envia uma quantidade limitada de seus dados pessoais para o serviço no qual você está a realizar a sua autenticação. Na maioria das vezes, você é obrigado a dar consentimento explícito para a transferência de informações. No entanto, em alguns casos, esse recurso é desativado a pedido de sua instituição.\n\nEsta página de perfil fornece informações que podem vir a ser dados pessoais. Estes dados são fornecidos pela sua instituição por meio da SURFconext que são encaminhados para cada serviço. Você também pode validar que dados pessoais estão a ser armazenados pela SURFconext e quais os serviços utilizou no passado."


### PR DESCRIPTION
Not having the GivenName in the released attribute set would halt
profile in the IntroductionController. Effectively showing an error
right after logging in to Profile.

This chane makes the use of the givenName attrib optional. An additional
change might be required ot make the UX more fluent as the header
element is now only stating 'Hi !' when logging in.

One step at a time!

https://www.pivotaltracker.com/story/show/179882084