### PR TITLE
Move makeRelease to bin folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ EngineBlock docs for more information on enabling the feature on the EngineBlock
 Please read: https://github.com/OpenConext/Stepup-Deploy/wiki/Release-Management for more information on the release strategy used in Openconext projects.
 
 ## Deployment
-Run `./makeRelease.sh` with the version number of the relevant release to create a deployable tar-ball.
+Run `./bin/makeRelease.sh` with the version number of the relevant release to create a deployable tar-ball.
 
 During deployment, unpack the tar on the deployment target and configure the
 application by placing the required `parameters.yaml` and
@@ -101,7 +101,7 @@ Running the release script can be run on bare metal, but this might result in si
 
 To have reproducible results, run the release script in your container:
 
-`docker run -v $PWD/Releases/:/root/Releases/ ghcr.io/openconext/openconext-containers/openconext-phpfpm-dev:latest /root/Releases/makeRelease.sh TAG/develop/master`
+`docker run -v ~/Releases/:/root/Releases/ -v $PWD/bin/makeRelease.sh:/root/Releases/makeRelease.sh ghcr.io/openconext/openconext-containers/openconext-phpfpm-dev:latest /root/Releases/makeRelease.sh`
 
 ## Texts and translations
 

--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -64,6 +64,7 @@ rm -f ${PROJECT_DIR}/.docheader &&
 rm -f ${PROJECT_DIR}/.env.* &&
 rm -f ${PROJECT_DIR}/.gitignore &&
 rm -f ${PROJECT_DIR}/.scrutinizer.yml &&
+rm -f ${PROJECT_DIR}/cypress.json &&
 rm -f ${PROJECT_DIR}/docker-compose.yml &&
 rm -f ${PROJECT_DIR}/makeRelease.sh &&
 rm -f ${PROJECT_DIR}/package.json &&
@@ -84,6 +85,7 @@ rm -rf ${PROJECT_DIR}/config/packages/test &&
 rm -rf ${PROJECT_DIR}/cypress &&
 rm -rf ${PROJECT_DIR}/docker &&
 rm -rf ${PROJECT_DIR}/node_modules &&
+rm -rf ${PROJECT_DIR}/Releases &&
 rm -rf ${PROJECT_DIR}/tests &&
 
 echo "Removing application cache, logs, bootstrap and parameters" &&


### PR DESCRIPTION
This coresponds with the sister project EngineBlock and makes sense from
a dev perspective as scripts aiding the development and release workflow
should be present in the bin folder.