### PR TITLE
Support mail and EULA trouble

### DIFF
--- a/src/OpenConext/Profile/Value/Consent/ServiceProvider.php
+++ b/src/OpenConext/Profile/Value/Consent/ServiceProvider.php
@@ -149,7 +149,7 @@ final class ServiceProvider
     }
 
     /**
-     * @return ContactEmailAddress
+     * @return string
      */
     public function getSupportEmail()
     {
@@ -157,7 +157,7 @@ final class ServiceProvider
             throw new LogicException('Service provider has no support e-mail address');
         }
 
-        return $this->supportEmail;
+        return $this->supportEmail->__toString();
     }
 
     /**

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/support.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/support.html.twig
@@ -4,7 +4,7 @@
         {% if sp.hasEulaUrl %}
             <li class="support__item support__eula">{% apply spaceless %}
                 {% include "@OpenConextProfile/svgs/network-information.svg" with { className: 'support__icon' } %}
-                <a href="{{ eulaUrl }}">{{ 'profile.my_services.eula'|trans }}</a>
+                <a href="{{ sp.eulaUrl }}">{{ 'profile.my_services.eula'|trans }}</a>
             {% endapply %}</li>
         {% endif %}
         {% if sp.hasSupportUrl(app.request.locale) %}
@@ -16,7 +16,7 @@
             {% endapply %}</li>
         {% endif %}
         {% if sp.hasSupportEmail %}
-            {% set supportEmail = supportEmail|replace({'mailto:': ''}) %}
+            {% set supportEmail = sp.supportEmail|replace({'mailto:': ''}) %}
             <li class="support__item support__email">{% apply spaceless %}
                 {% include "@OpenConextProfile/svgs/email-action-unread.svg" with { className: 'support__icon' } %}
                 <a href="mailto:{{ supportEmail }}">{{ 'profile.my_services.supportEmail'|trans }}</a>


### PR DESCRIPTION
The Support email link was not rendered correctly (either empty or yielding a 500 error). This was fixed in this PR by calling the getter on the SP variable. In the process a stray { was also removed from the template.