### PR TITLE
Docker: OpenConext prep script moved to /usr/local/sbin

### DIFF
--- a/docker/conf/start.sh
+++ b/docker/conf/start.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # script set in background
-setsid /tmp/prep_oc.sh > output.txt &
-
+setsid /usr/local/sbin/prep_oc.sh > output.txt &
 # run systemd
 exec /usr/sbin/init


### PR DESCRIPTION
The script that preps the OpenConext image to use the profile version that is in the seperate Docker image was moved to /usr/local/sbin, but not yet started there, as the start.sh script still contained the old location. This fixes that. 