### PR TITLE
Order the consent list alphabetically

### DIFF
--- a/src/OpenConext/Profile/Tests/Value/SpecifiedConsentListTest.php
+++ b/src/OpenConext/Profile/Tests/Value/SpecifiedConsentListTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright 2021 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\Profile\Tests\Value;
+
+use Mockery as m;
+use OpenConext\Profile\Value\Consent\ServiceProvider;
+use OpenConext\Profile\Value\SpecifiedConsent;
+use OpenConext\Profile\Value\SpecifiedConsentList;
+use PHPUnit\Framework\TestCase;
+use function array_shift;
+
+class SpecifiedConsentListTest extends TestCase
+{
+    public function test_it_can_order_by_display_name_of_sp()
+    {
+        $locale = 'en';
+        $specifiedConsent = [
+            $this->buildMockSpecifiedConsent($locale, 'C-service'),
+            $this->buildMockSpecifiedConsent($locale, 'A-service'),
+            $this->buildMockSpecifiedConsent($locale, 'B-service'),
+        ];
+        $list = SpecifiedConsentList::createWith($specifiedConsent);
+        $list->sortByDisplayName('en');
+        $sorted = $list->getIterator()->getArrayCopy();
+        $this->assertEquals('A-service', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+        $this->assertEquals('B-service', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+        $this->assertEquals('C-service', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+    }
+
+    /**
+     * The entities with a display name are sorted on top of the list, followed by the ones with only an entityID.
+     * Both lists are sorted alphabetically.
+     */
+    public function test_it_can_order_by_display_name_of_sp_handle_sps_without_display_name_correctly()
+    {
+        $locale = 'en';
+        $specifiedConsent = [
+            $this->buildMockSpecifiedConsent($locale, '', 'https://aa.example.com/metadata'),
+            $this->buildMockSpecifiedConsent($locale, 'https://selfservice'),
+            $this->buildMockSpecifiedConsent($locale, '', 'https://selfservice.stepup.example.com/metadata'),
+            $this->buildMockSpecifiedConsent($locale, 'Healty-service'),
+        ];
+        $list = SpecifiedConsentList::createWith($specifiedConsent);
+        $list->sortByDisplayName('en');
+        /** @var SpecifiedConsent[] $sorted */
+        $sorted = $list->getIterator()->getArrayCopy();
+        $this->assertEquals('Healty-service', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+        $this->assertEquals('https://selfservice', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+        $this->assertEquals('https://aa.example.com/metadata', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+        $this->assertEquals('https://selfservice.stepup.example.com/metadata', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+    }
+
+    public function test_it_can_order_nothing()
+    {
+        $specifiedConsent = [];
+        $list = SpecifiedConsentList::createWith($specifiedConsent);
+        $list->sortByDisplayName('nl');
+        $this->assertEmpty($list);
+    }
+
+    private function buildMockSpecifiedConsent(string $locale, string $displayName, string $entityId = '')
+    {
+        $mockSp = m::mock(ServiceProvider::class);
+        if ($entityId === '') {
+            $mockSp->shouldReceive('getLocaleAwareEntityName')->with($locale)->andReturn($displayName);
+            $mockSp->shouldReceive('getDisplayName->hasFilledTranslationForLocale')->with($locale)->andReturn(true);
+        } else {
+            $mockSp->shouldReceive('getLocaleAwareEntityName')->with($locale)->andReturn($entityId);
+            $mockSp->shouldReceive('getDisplayName->hasFilledTranslationForLocale')->with($locale)->andReturn(false);
+        }
+
+        $mock = m::mock(SpecifiedConsent::class);
+        $mock->shouldReceive('getServiceProvider')->andReturn($mockSp);
+        return $mock;
+    }
+}

--- a/src/OpenConext/Profile/Value/Consent/ServiceProvider.php
+++ b/src/OpenConext/Profile/Value/Consent/ServiceProvider.php
@@ -26,7 +26,7 @@ use OpenConext\Profile\Value\ContactEmailAddress;
 use OpenConext\Profile\Value\Entity;
 use OpenConext\Profile\Value\Url;
 
-final class ServiceProvider
+class ServiceProvider
 {
     /**
      * @var Entity

--- a/src/OpenConext/Profile/Value/SpecifiedConsent.php
+++ b/src/OpenConext/Profile/Value/SpecifiedConsent.php
@@ -18,6 +18,7 @@
 
 namespace OpenConext\Profile\Value;
 
+use OpenConext\Profile\Value\Consent\ServiceProvider;
 use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
 
@@ -137,5 +138,10 @@ class SpecifiedConsent
         }
 
         return '';
+    }
+
+    public function getServiceProvider(): ServiceProvider
+    {
+        return $this->consent->getServiceProvider();
     }
 }

--- a/src/OpenConext/Profile/Value/SpecifiedConsentList.php
+++ b/src/OpenConext/Profile/Value/SpecifiedConsentList.php
@@ -21,6 +21,9 @@ namespace OpenConext\Profile\Value;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use OpenConext\Profile\Exception\LogicException;
+use function ksort;
+use const SORT_STRING;
 
 final class SpecifiedConsentList implements IteratorAggregate, Countable
 {
@@ -48,6 +51,23 @@ final class SpecifiedConsentList implements IteratorAggregate, Countable
         }
     }
 
+    public function sortByDisplayName(string $locale): void
+    {
+        $sorted = [];
+        $sortedByEntityId = [];
+        /** @var SpecifiedConsent $consent */
+        foreach ($this->getIterator() as $consent) {
+            $displayName = $consent->getServiceProvider()->getLocaleAwareEntityName($locale);
+            if ($consent->getServiceProvider()->getDisplayName()->hasFilledTranslationForLocale($locale)) {
+                $sorted[$displayName] = $consent;
+            } else {
+                $sortedByEntityId[$displayName] = $consent;
+            }
+        }
+        ksort($sorted, SORT_STRING);
+        ksort($sortedByEntityId, SORT_STRING);
+        $this->specifiedConsents = $sorted +  $sortedByEntityId;
+    }
     /**
      * @param SpecifiedConsent $specifiedConsent
      */

--- a/src/OpenConext/ProfileBundle/Controller/MyServicesController.php
+++ b/src/OpenConext/ProfileBundle/Controller/MyServicesController.php
@@ -90,6 +90,7 @@ class MyServicesController
 
         $user = $this->authenticatedUserProvider->getCurrentUser();
         $specifiedConsentList = $this->specifiedConsentListService->getListFor($user);
+        $specifiedConsentList->sortByDisplayName($request->getLocale());
 
         $this->logger->notice(sprintf('Showing %s services on My Services page', count($specifiedConsentList)));
 


### PR DESCRIPTION
The SpecifiedConsentList can now order its collection items on the display name of the SP. If the SP does not have a displayname for the specified locale, it is put to the bottom of the listing (showing the entityId). The entityId items are then also sorted alphabetically.

https://www.pivotaltracker.com/story/show/179919734