### PR TITLE
Temporarily disable AA aatributes in my services

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/service-information.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/service-information.html.twig
@@ -3,13 +3,12 @@
     <p>{{ 'profile.my_services.no_attribute_released'|trans }}</p>
 {% else %}
     {% for sourceName, releasedAttributes in specifiedConsent.releasedAttributesGroupedBySource  %}
+        {# TODO: the AA sourced attributes are yet to be rendered see: https://www.pivotaltracker.com/story/show/179920711 for details #}
+        {% if sourceName == 'idp' %}
         <ul class="attributeList">
-            {% if sourceName == 'idp' %}
-                {% include '@OpenConextProfile/MyServices/AttributeList/idp.html.twig' %}
-            {% else %}
-                {% include '@OpenConextProfile/MyServices/AttributeList/aa.html.twig' %}
-            {% endif %}
+            {% include '@OpenConextProfile/MyServices/AttributeList/idp.html.twig' %}
         </ul>
+        {% endif %}
     {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Awaiting a consensus in how to style and display the AA attributes, they are now not rendered altogether. As they would only cause confusion. For a discussion on what the new design should be like, see:

https://www.pivotaltracker.com/story/show/179920711