### PR TITLE
Ensure support icons have the right color

### DIFF
--- a/assets/css/pages/myServices/serviceList.scss
+++ b/assets/css/pages/myServices/serviceList.scss
@@ -42,6 +42,8 @@
 }
 
 .support__icon {
+  fill: none;
   margin-right: 1rem;
+  stroke: $buttonBlue;
   width: 24px;
 }


### PR DESCRIPTION
Prior to this change, the icons showed up black in firefox.

This change ensures they are blue in firefox as well.

Ticket on pivotal: https://www.pivotaltracker.com/story/show/180095726