### PR TITLE
Ensure the something incorrect disclosure is shown

### DIFF
--- a/assets/js/tooltip.js
+++ b/assets/js/tooltip.js
@@ -31,21 +31,21 @@ window.addEventListener('load', function () {
         tooltipOrModal.addEventListener('click', function (e) {
             const id = e.target.getAttribute('for');
             const checkbox = document.getElementById(id);
-            const expanded = checkbox.getAttribute('aria-expanded');
 
             if (!!checkbox) {
                 changeAriaExpanded(checkbox);
                 changeAriaPressed(checkbox);
-            }
 
-            setTimeout(function () {
-                const value = document.querySelector(`[data-for ="${id}"]`);
-                if (expanded === 'false' && !!value) {
-                    value.focus();
-                } else {
-                    e.target.focus();
-                }
-            }, 200);
+                setTimeout(function () {
+                    const expanded = checkbox.getAttribute('aria-expanded');
+                    const value = document.querySelector(`[data-for ="${id}"]`);
+                    if (expanded === 'false' && !!value) {
+                        value.focus();
+                    } else {
+                        e.target.focus();
+                    }
+                }, 200);
+            }
         });
 
         tooltipOrModal.addEventListener('keydown', function (e) {

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
@@ -73,13 +73,14 @@
             <a class="idpRow__supportUrl" href="{{ 'profile.my_services.idpRow.support_url'|trans }}" target="_blank" rel="noreferrer noopener">{{ 'profile.my_services.idpRow.support_link'|trans }}</a>
         </div>
     {% else %}
-        <input type="checkbox" tabindex="-1" aria-hidden="true" class="modal visually-hidden" id="{{ orgId|trim }}" name="{{ orgId|trim }}" />
+        {% set sanitizedId = orgId|trim|escape('html_attr') %}
+        <input type="checkbox" tabindex="-1" aria-hidden="true" class="modal visually-hidden" id="{{ sanitizedId }}" name="{{ sanitizedId }}" />
         {# note: the empty label is for display on mobile #}
         <p>{{ consentProvidedBy|raw }}<label tabindex="0" for="{{ id|trim }}" class="modal"></label>
         </p>
         {# note: the div is here only for IE11, as soon as IE11 support is scrapped, this can be removed along with the CSS/JS for it  #}
         <div class="ie11__label">
-            <label tabindex="0" for="{{ orgId|trim }}" class="modal">
+            <label tabindex="0" for="{{ sanitizedId }}" class="modal">
                 <span class="label-text">{{ 'profile.my_services.idpRow.attributes_correction_text'|trans }}</span>
             </label>
             <span class="visually-hidden">{{ 'accessibility.button_screenreader'|trans }}</span>

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/AttributeList/idp.html.twig
@@ -73,16 +73,13 @@
             <a class="idpRow__supportUrl" href="{{ 'profile.my_services.idpRow.support_url'|trans }}" target="_blank" rel="noreferrer noopener">{{ 'profile.my_services.idpRow.support_link'|trans }}</a>
         </div>
     {% else %}
-        {% set id %}
-            incorrect_{{ sourceName }}{{ loop.index }}
-        {% endset %}
-        <input type="checkbox" tabindex="-1" aria-hidden="true" class="modal visually-hidden" id="{{ id|trim }}" name="{{ id|trim }}" />
+        <input type="checkbox" tabindex="-1" aria-hidden="true" class="modal visually-hidden" id="{{ orgId|trim }}" name="{{ orgId|trim }}" />
         {# note: the empty label is for display on mobile #}
         <p>{{ consentProvidedBy|raw }}<label tabindex="0" for="{{ id|trim }}" class="modal"></label>
         </p>
         {# note: the div is here only for IE11, as soon as IE11 support is scrapped, this can be removed along with the CSS/JS for it  #}
         <div class="ie11__label">
-            <label tabindex="0" for="{{ id|trim }}" class="modal">
+            <label tabindex="0" for="{{ orgId|trim }}" class="modal">
                 <span class="label-text">{{ 'profile.my_services.idpRow.attributes_correction_text'|trans }}</span>
             </label>
             <span class="visually-hidden">{{ 'accessibility.button_screenreader'|trans }}</span>

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/consent-list.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/consent-list.html.twig
@@ -4,8 +4,7 @@
         {% set sp = consent.serviceProvider %}
         {% set orgId = sp.entity.entityId.entityId|trim|split(' ')|join %}
         {% set id = 'tooltip%index%%orgId%'|replace({ '%index%': loop.index, '%orgId%': orgId })|trim %}
-
-        <li class="service__listItem listDetails__item">
+        <li class="service__listItem listDetails__item" data-orgId="{{ orgId }}">
             <details class="service__details listDetails__details">
                 <summary class="service__name listDetails__name">
                     <h2 class="service__title listDetails__title">


### PR DESCRIPTION
Prior to this change, the id for the input element toggling the tooltip was generated incorrectly.  This made all labels of different organisations toggle the same disclosure modal.

This change uses the organizationId as an id for the input.  Thus ensuring that the modal is toggled correctly.

Pivotal ticket: https://www.pivotaltracker.com/story/show/180095824