### PR TITLE
Downgrade 'normal operation' log messages to info

### DIFF
--- a/src/OpenConext/ProfileBundle/Controller/IntroductionController.php
+++ b/src/OpenConext/ProfileBundle/Controller/IntroductionController.php
@@ -72,7 +72,7 @@ class IntroductionController
     public function overviewAction()
     {
         $this->guard->userIsLoggedIn();
-        $this->logger->notice('Showing Introduction page');
+        $this->logger->info('Showing Introduction page');
         $attributeDefinition = new AttributeDefinition(
             'givenName',
             'urn:mace:dir:attribute-def:givenName',

--- a/src/OpenConext/ProfileBundle/Controller/LocaleController.php
+++ b/src/OpenConext/ProfileBundle/Controller/LocaleController.php
@@ -74,7 +74,7 @@ class LocaleController
     {
         $this->guard->userIsLoggedIn();
 
-        $this->logger->notice('User requested to switch locale');
+        $this->logger->info('User requested to switch locale');
 
         $returnUrl = $request->query->get('return-url');
 

--- a/src/OpenConext/ProfileBundle/Controller/MyConnectionsController.php
+++ b/src/OpenConext/ProfileBundle/Controller/MyConnectionsController.php
@@ -106,7 +106,7 @@ class MyConnectionsController
     public function overviewAction(Request $request)
     {
         $this->guard->userIsLoggedIn();
-        $this->logger->notice('Showing My Connections page');
+        $this->logger->info('Showing My Connections page');
 
         $user = $this->userProvider->getCurrentUser();
         $attributes = $this->service->findByUser($user);

--- a/src/OpenConext/ProfileBundle/Controller/MyProfileController.php
+++ b/src/OpenConext/ProfileBundle/Controller/MyProfileController.php
@@ -65,7 +65,7 @@ class MyProfileController
     {
         $this->guard->userIsLoggedIn();
 
-        $this->logger->notice('Showing My Profile page');
+        $this->logger->info('Showing My Profile page');
 
         $user = $this->userService->getUser();
 

--- a/src/OpenConext/ProfileBundle/Controller/MyServicesController.php
+++ b/src/OpenConext/ProfileBundle/Controller/MyServicesController.php
@@ -98,14 +98,14 @@ class MyServicesController
     {
         $this->guard->userIsLoggedIn();
 
-        $this->logger->notice('User requested My Services page');
+        $this->logger->info('User requested My Services page');
 
         $locale = $request->getLocale();
         $user = $this->authenticatedUserProvider->getCurrentUser();
         $specifiedConsentList = $this->specifiedConsentListService->getListFor($user);
         $specifiedConsentList->sortByDisplayName($locale);
 
-        $this->logger->notice(sprintf('Showing %s services on My Services page', count($specifiedConsentList)));
+        $this->logger->info(sprintf('Showing %s services on My Services page', count($specifiedConsentList)));
 
         $organization = $this->institutionRepository->getOrganizationAndLogoForIdp($user);
 

--- a/src/OpenConext/ProfileBundle/Controller/MySurfConextController.php
+++ b/src/OpenConext/ProfileBundle/Controller/MySurfConextController.php
@@ -67,7 +67,7 @@ class MySurfConextController
     {
         $this->guard->userIsLoggedIn();
 
-        $this->logger->notice('Showing My SURFconext page');
+        $this->logger->info('Showing My SURFconext page');
 
         $user = $this->userService->getUser();
 

--- a/src/OpenConext/ProfileBundle/Controller/SamlController.php
+++ b/src/OpenConext/ProfileBundle/Controller/SamlController.php
@@ -55,7 +55,7 @@ class SamlController
      */
     public function metadataAction()
     {
-        $this->logger->notice('Showing SAML metadata');
+        $this->logger->info('Showing SAML metadata');
 
         return new XMLResponse($this->metadataFactory->generate());
     }

--- a/src/OpenConext/ProfileBundle/Security/Firewall/SamlListener.php
+++ b/src/OpenConext/ProfileBundle/Security/Firewall/SamlListener.php
@@ -151,7 +151,7 @@ class SamlListener implements ListenerInterface
             throw new AuthenticationException('Unknown or unexpected InResponseTo in SAMLResponse');
         }
 
-        $logger->notice('Successfully processed SAMLResponse, attempting to authenticate');
+        $logger->info('Successfully processed SAMLResponse, attempting to authenticate');
 
         $token = new SamlToken();
         $token->assertion = $assertion;
@@ -171,7 +171,7 @@ class SamlListener implements ListenerInterface
         $this->session->migrate();
 
         $event->setResponse(new RedirectResponse($this->stateHandler->getCurrentRequestUri()));
-        $logger->notice('Authentication succeeded, redirecting to original location');
+        $logger->info('Authentication succeeded, redirecting to original location');
     }
 
     /**
@@ -200,7 +200,7 @@ class SamlListener implements ListenerInterface
         $event->setResponse($this->samlInteractionProvider->initiateSamlRequest());
 
         $logger = $this->logger;
-        $logger->notice('Sending AuthnRequest');
+        $logger->info('Sending AuthnRequest');
     }
 
     /**


### PR DESCRIPTION
These are the kinds of situations that are just run of the mill (show a specific
page, mostly) and do not need to be logged above the passthrough level. In the
development environment one can override the passthrouh level to show these
if necessary.