### PR TITLE
Create release artifacts when project is tagged

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,55 @@
+name: tag-release
+on:
+  push:
+    tags:
+      - "*.*.*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Output the semver tag to the tag variable
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Pull OpenConext build container
+        run: docker-compose -f ./docker-compose-tag-release.yml up -d
+      - name: Make the release files
+        run: docker-compose exec -T openconext sh -c 'HOME=/var/www/html ./bin/makeRelease.sh ${{ steps.vars.outputs.tag }}'
+      - name: Create Draft Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.vars.outputs.tag }}
+          release_name: ${{ steps.vars.outputs.tag }}
+          body: Auto generated release. Please update these release notes manually.
+          draft: true
+          prerelease: false
+      - uses: actions/upload-release-asset@v1.0.1
+        name: Upload the release artefact tarbal
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./Releases/OpenConext-profile-${{ steps.vars.outputs.tag }}.tar.gz
+          asset_name: OpenConext-profile-${{ steps.vars.outputs.tag }}.tar.gz
+          asset_content_type: application/gzip
+      - uses: actions/upload-release-asset@v1.0.1
+        name: Upload the release artefact verification hash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./Releases/OpenConext-profile-${{ steps.vars.outputs.tag }}.sha
+          asset_name: OpenConext-profile-${{ steps.vars.outputs.tag }}.sha
+          asset_content_type: text/plain
+      - uses: eregon/publish-release@v1
+        name: Publish the new release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ steps.create_release.outputs.id }}

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ To have reproducible results, run the release script in your container:
 
 `docker run -v ~/Releases/:/root/Releases/ -v $PWD/bin/makeRelease.sh:/root/Releases/makeRelease.sh ghcr.io/openconext/openconext-containers/openconext-phpfpm-dev:latest /root/Releases/makeRelease.sh`
 
+Note that the release script is run automatically on pushing a new semver tag to Github. The release script builds the release artifacts and uploads them to the release page.
+
 ## Texts and translations
 
 When adding translatable keys, the easiest way to work is to add them in the twig templates first (eg. `'some.key'|trans`) and then add them to the translations files (see `<root>/translations`).

--- a/bin/makeRelease.sh
+++ b/bin/makeRelease.sh
@@ -66,6 +66,7 @@ rm -f ${PROJECT_DIR}/.gitignore &&
 rm -f ${PROJECT_DIR}/.scrutinizer.yml &&
 rm -f ${PROJECT_DIR}/cypress.json &&
 rm -f ${PROJECT_DIR}/docker-compose.yml &&
+rm -f ${PROJECT_DIR}/docker-compose-tag-release.yml &&
 rm -f ${PROJECT_DIR}/makeRelease.sh &&
 rm -f ${PROJECT_DIR}/package.json &&
 rm -f ${PROJECT_DIR}/package-lock.json &&

--- a/docker-compose-tag-release.yml
+++ b/docker-compose-tag-release.yml
@@ -1,0 +1,12 @@
+---
+
+version: "3.8"
+
+services:
+  openconext:
+    image: "ghcr.io/openconext/openconext-containers/openconext-phpfpm-dev:latest"
+    volumes:
+      - .:/var/www/html
+    working_dir: /var/www/html
+    environment:
+      - PHPFPM_PORT=9000


### PR DESCRIPTION
In this workflow an incoming tag is triggering the makeRelease script. The output of this script (the artifacts) are used to create a new release page on the projects GitHub releases page. The artifacts are then uploaded to that new release.

The one thing remaining is to add the release notes to the release. This is now set with a small placeholder message