### PR TITLE
Add the option to store sessions in the database

### DIFF
--- a/config/legacy/parameters.yaml.dist
+++ b/config/legacy/parameters.yaml.dist
@@ -56,8 +56,4 @@ parameters:
     #session_handler: 'Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler'
     session_handler: ~
     # Database settings when using a db to store sessions. Unused in the default setup
-    database_user: profilerw
-    database_name: profile
-    database_password: secret
-    database_host: localhost
-
+    dsn: mysql://profilerw:secret@localhost/profile?serverVersion=5.7

--- a/config/legacy/parameters.yaml.dist
+++ b/config/legacy/parameters.yaml.dist
@@ -50,3 +50,14 @@ parameters:
     information_request_email_to: help@domain.invalid
 
     remove_consent_enabled: false
+
+    # Session handler override
+    # Change to the following to use the database to store sessions:  
+    #session_handler: 'Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler'
+    session_handler: ~
+    # Database settings when using a db to store sessions. Unused in the default setup
+    database_user: profilerw
+    database_name: profile
+    database_password: secret
+    database_host: localhost
+

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -9,6 +9,6 @@ framework:
   default_locale: "%default_locale%"
   trusted_hosts: ~
   session:
-    handler_id: ~
+    handler_id: "%session_handler%"
   fragments: ~
   http_method_override: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,5 +26,5 @@ services:
         alias: OpenConext\ProfileBundle\Service\GlobalViewParameters
     Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
         arguments:
-            - 'mysql://%database_user%:%database_password%@%database_host%/%database_name%?serverVersion=5.7'
+            - '%dsn%'
     Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,3 +24,7 @@ services:
             - '%remove_consent_enabled%'
     open_conext.profile_bundle.service.global_view_parameters:
         alias: OpenConext\ProfileBundle\Service\GlobalViewParameters
+    Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
+        arguments:
+            - 'mysql://%database_user%:%database_password%@%database_host%/%database_name%?serverVersion=5.7'
+    Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler:


### PR DESCRIPTION
When sticky sessions are not an option it might be usefull to store sessions in the database. This adds a configuration parameter to do so.

The default is still file based session storage