### PR TITLE
Log which user authenticated to the application.

### DIFF
--- a/src/OpenConext/ProfileBundle/Security/Firewall/SamlListener.php
+++ b/src/OpenConext/ProfileBundle/Security/Firewall/SamlListener.php
@@ -171,7 +171,9 @@ class SamlListener implements ListenerInterface
         $this->session->migrate();
 
         $event->setResponse(new RedirectResponse($this->stateHandler->getCurrentRequestUri()));
-        $logger->info('Authentication succeeded, redirecting to original location');
+        $logger->notice('Authentication succeeded, redirecting to original location',
+            ['user' => (string)$authToken->getUser()]
+        );
     }
 
     /**


### PR DESCRIPTION
Previously we've reduced the loglevel of a number of events to info level,
but an actual login action deserves to stand out at notice level. We
add the username of the authenticated user so that if anything goes wrong
or is reported, we can find out who it was.

Before:
```
Mar  1 12:07:20 t06.ams.surfconext.nl openconext-profile[26631]: app.INFO: Authentication succeeded, redirecting to original location [] []
```

After:
```
Mar  1 12:28:15 t06.ams.surfconext.nl openconext-profile[30817]: app.NOTICE: Authentication succeeded, redirecting to original location {"user":"urn:collab:person:surfnet.nl:kinkhorst"} []
```
