### PR TITLE
Prevent unsafe-inline CSP errors on SVG images

### DIFF
--- a/assets/css/pages/myServices/serviceList.scss
+++ b/assets/css/pages/myServices/serviceList.scss
@@ -41,9 +41,3 @@
   }
 }
 
-.support__icon {
-  fill: none;
-  margin-right: 1rem;
-  stroke: $buttonBlue;
-  width: 24px;
-}

--- a/assets/css/shared/shared.scss
+++ b/assets/css/shared/shared.scss
@@ -6,6 +6,7 @@
 @import './header.scss';
 @import './main.scss';
 @import './navigation.scss';
+@import './svg.scss';
 
 :root {
     @include motion {

--- a/assets/css/shared/svg.scss
+++ b/assets/css/shared/svg.scss
@@ -1,30 +1,11 @@
 @import '../helpers/variables';
 
-.header {
-  background-color: $oceanBlue;
-  box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.5);
-  max-height: calculateRem(60px);
-  padding: calculateRem(11px) 1rem;
-  position: relative;
-}
-
-.header__profile {
-  color: $white;
-  font-family: 'Nunito', sans-serif;
-  font-size: $f-small;
-  font-weight: $bolder;
-  left: 146px;
-  letter-spacing: .26px;
-  margin: 0;
-  position: absolute;
-  top: 13px;
-}
-
-.header__homeLink {
-  display: inline-block;
-  padding-right: 4rem;
-
-  &:focus {
-    @include focus-style($oceanBlue);
-  }
+.support__icon {
+  fill: none;
+  margin-right: 1rem;
+  stroke: $buttonBlue;
+  width: 24px;
+  stroke-linecap:round;
+  stroke-linejoin:round;
+  stroke-width:1.5px;
 }

--- a/assets/css/shared/svg.scss
+++ b/assets/css/shared/svg.scss
@@ -1,0 +1,30 @@
+@import '../helpers/variables';
+
+.header {
+  background-color: $oceanBlue;
+  box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.5);
+  max-height: calculateRem(60px);
+  padding: calculateRem(11px) 1rem;
+  position: relative;
+}
+
+.header__profile {
+  color: $white;
+  font-family: 'Nunito', sans-serif;
+  font-size: $f-small;
+  font-weight: $bolder;
+  left: 146px;
+  letter-spacing: .26px;
+  margin: 0;
+  position: absolute;
+  top: 13px;
+}
+
+.header__homeLink {
+  display: inline-block;
+  padding-right: 4rem;
+
+  &:focus {
+    @include focus-style($oceanBlue);
+  }
+}

--- a/config/packages/dev/nelmio_security.yaml
+++ b/config/packages/dev/nelmio_security.yaml
@@ -9,4 +9,3 @@ nelmio_security:
         - unsafe-inline
       style-src:
         - self
-        - unsafe-inline

--- a/src/OpenConext/ProfileBundle/Resources/views/svgs/email-action-unread.svg
+++ b/src/OpenConext/ProfileBundle/Resources/views/svgs/email-action-unread.svg
@@ -1,9 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="{{className}}">
-    <defs>
-        <style>
-            .a{fill:none;stroke:#0077c8;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;}
-        </style>
-    </defs>
     <title/>
     <rect class="a" x="1.5" y="4.75" width="21" height="15" rx="1.5" ry="1.5"/>
     <path class="a" d="M22.161,5.3l-8.144,6.264a3.308,3.308,0,0,1-4.034,0L1.839,5.3"/>

--- a/src/OpenConext/ProfileBundle/Resources/views/svgs/network-information.svg
+++ b/src/OpenConext/ProfileBundle/Resources/views/svgs/network-information.svg
@@ -1,9 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="{{className}}">
-    <defs>
-        <style>
-            .a{fill:none;stroke:#0077c8;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;}
-        </style>
-    </defs>
     <title/>
     <circle class="a" cx="17.25" cy="17.25" r="6"/>
     <line class="a" x1="17.25" y1="20.25" x2="17.25" y2="17.25"/>


### PR DESCRIPTION
SVG images that are included on the page would trigger CSP usafe inline errors. Loosening the CSP would open us to a host of other vulnerabilities. So fixing the SVG's was the way to go.

Having the inline styles in a dedicated stylesheet proved to be the most pragmatic solution. Thanks @Badlapje for thinking out of the box with me on this one! 

Bugreport: https://www.pivotaltracker.com/story/show/180407180