### PR TITLE
Enable test-integration runs on develop

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       package_name:
-        description: 'The name of the package to delete'     
+        description: 'The name of the package to delete'
         required: true
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-    
+
     - name: Docker meta_phpfpm
       id: metaweb
       uses: docker/metadata-action@v3
@@ -61,7 +61,7 @@ jobs:
         push: true
         target: phpfpm-build
         tags:  ${{ steps.metafpm.outputs.tags }}
-    
+
     - name: Build the Apache container and push to GitHub Container Registry
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,20 +1,15 @@
 name: test-integration
 on:
   push:
-    branches:
-      - master
-      - feature/redesign
+    branches: [ develop, master ]
   pull_request:
-  # run at 6 hour UTC
-  schedule:
-    - cron: "0 6 * * *"
+    branches: [ develop ]
+
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      PROD_PHP: php72
-      DOCKER_COMPOSE: docker-compose -f ../docker-compose.yml
+    if: always()
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Tests/Value/ConsentListFactoryTest.php
@@ -56,6 +56,7 @@ final class ConsentListFactoryTest extends TestCase
                 'service_provider' => [
                     'entity_id'     => $firstEntityId,
                     'display_name'  => ['en' => '', 'nl' => '',],
+                    'organization_display_name'  => ['en' => 'OpenConext', 'nl' => 'OpenConext'],
                     'support_url'  => ['en' => 'https://example.org/support-en', 'nl' => 'https://example.org/support-nl'],
                     'eula_url'      => $firstEula,
                     'support_email' => null,
@@ -68,6 +69,7 @@ final class ConsentListFactoryTest extends TestCase
                 'service_provider' => [
                     'entity_id'     => $secondEntityId,
                     'display_name'  => ['en' => 'OpenConext ServiceRegistry', 'nl' => 'OpenConext ServiceRegistry'],
+                    'organization_display_name'  => ['en' => 'OpenConext', 'nl' => 'OpenConext'],
                     'support_url'  => ['en' => 'https://example.org/support-en', 'nl' => 'https://example.org/support-nl'],
                     'eula_url'      => null,
                     'support_email' => $secondSupportEmail,
@@ -83,6 +85,7 @@ final class ConsentListFactoryTest extends TestCase
                 new ServiceProvider(
                     new Entity(new EntityId($firstEntityId), EntityType::SP()),
                     new DisplayName(['nl' => '', 'en' => '']),
+                    new DisplayName(['nl' => 'OpenConext', 'en' => 'OpenConext']),
                     new NameIdFormat('test'),
                     new Url($firstEula),
                     null,
@@ -96,6 +99,7 @@ final class ConsentListFactoryTest extends TestCase
                 new ServiceProvider(
                     new Entity(new EntityId($secondEntityId), EntityType::SP()),
                     new DisplayName(['nl' => 'OpenConext ServiceRegistry', 'en' => 'OpenConext ServiceRegistry']),
+                    new DisplayName(['nl' => 'OpenConext', 'en' => 'OpenConext']),
                     new NameIdFormat('test'),
                     null,
                     new ContactEmailAddress($secondSupportEmail),

--- a/src/OpenConext/Profile/Tests/Value/SpecifiedConsentListTest.php
+++ b/src/OpenConext/Profile/Tests/Value/SpecifiedConsentListTest.php
@@ -20,6 +20,7 @@ namespace OpenConext\Profile\Tests\Value;
 
 use Mockery as m;
 use OpenConext\Profile\Value\Consent\ServiceProvider;
+use OpenConext\Profile\Value\DisplayName;
 use OpenConext\Profile\Value\SpecifiedConsent;
 use OpenConext\Profile\Value\SpecifiedConsentList;
 use PHPUnit\Framework\TestCase;
@@ -79,10 +80,20 @@ class SpecifiedConsentListTest extends TestCase
         $mockSp = m::mock(ServiceProvider::class);
         if ($entityId === '') {
             $mockSp->shouldReceive('getLocaleAwareEntityName')->with($locale)->andReturn($displayName);
-            $mockSp->shouldReceive('getDisplayName->hasFilledTranslationForLocale')->with($locale)->andReturn(true);
+            $displayNameMock = m::mock(DisplayName::class);
+            $displayNameMock
+                ->shouldReceive('hasFilledTranslationForLocale')
+                ->with($locale)
+                ->andReturn(true);
+            $mockSp->shouldReceive('getDisplayName')->andReturn($displayNameMock);
         } else {
             $mockSp->shouldReceive('getLocaleAwareEntityName')->with($locale)->andReturn($entityId);
-            $mockSp->shouldReceive('getDisplayName->hasFilledTranslationForLocale')->with($locale)->andReturn(false);
+            $displayNameMock = m::mock(DisplayName::class);
+            $displayNameMock
+                ->shouldReceive('hasFilledTranslationForLocale')
+                ->with($locale)
+                ->andReturn(false);
+            $mockSp->shouldReceive('getDisplayName')->andReturn($displayNameMock);
         }
 
         $mock = m::mock(SpecifiedConsent::class);

--- a/src/OpenConext/Profile/Tests/Value/SpecifiedConsentTest.php
+++ b/src/OpenConext/Profile/Tests/Value/SpecifiedConsentTest.php
@@ -56,6 +56,9 @@ class SpecifiedConsentTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new DisplayName([
+                    'en' => 'Some organization display name'
+                ]),
                 new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
@@ -95,6 +98,9 @@ class SpecifiedConsentTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new DisplayName([
+                    'en' => 'Some organization display name'
+                ]),
                 new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
@@ -126,6 +132,9 @@ class SpecifiedConsentTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new DisplayName([
+                    'en' => 'Some organization display name'
+                ]),
                 new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
@@ -154,6 +163,9 @@ class SpecifiedConsentTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new DisplayName([
+                    'en' => 'Some organization display name'
+                ]),
                 new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
@@ -170,7 +182,7 @@ class SpecifiedConsentTest extends TestCase
             Arp::createWith($arpData)
         );
 
-        $groupedBySources = $specifiedConsent->getReleasedAttributesGroupedBySource();
+        $groupedBySources = $specifiedConsent->getAttributeAggregatedAttributes();
 
         $this->assertTrue($specifiedConsent->hasMultipleSources());
         $this->assertCount(3, $groupedBySources);

--- a/src/OpenConext/Profile/Value/DisplayName.php
+++ b/src/OpenConext/Profile/Value/DisplayName.php
@@ -21,7 +21,7 @@ namespace OpenConext\Profile\Value;
 use OpenConext\Profile\Assert;
 use OpenConext\Profile\Exception\LogicException;
 
-final class DisplayName
+class DisplayName
 {
     /**
      * @var string[]

--- a/src/OpenConext/ProfileBundle/Security/Firewall/SamlListener.php
+++ b/src/OpenConext/ProfileBundle/Security/Firewall/SamlListener.php
@@ -171,7 +171,8 @@ class SamlListener implements ListenerInterface
         $this->session->migrate();
 
         $event->setResponse(new RedirectResponse($this->stateHandler->getCurrentRequestUri()));
-        $logger->notice('Authentication succeeded, redirecting to original location',
+        $logger->notice(
+            'Authentication succeeded, redirecting to original location',
             ['user' => (string)$authToken->getUser()]
         );
     }

--- a/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
+++ b/src/OpenConext/ProfileBundle/Tests/Service/AttributeReleasePolicyServiceTest.php
@@ -168,6 +168,9 @@ class AttributeReleasePolicyServiceTest extends TestCase
                 new DisplayName([
                     'en' => 'Some display name'
                 ]),
+                new DisplayName([
+                    'en' => 'Some organization display name'
+                ]),
                 new NameIdFormat(''),
                 new Url('http://some-eula-url.example'),
                 new ContactEmailAddress('some@email.example')
@@ -183,6 +186,9 @@ class AttributeReleasePolicyServiceTest extends TestCase
                 ),
                 new DisplayName([
                     'en' =>'Another display name'
+                ]),
+                new DisplayName([
+                    'en' => 'Some organization display name'
                 ]),
                 new NameIdFormat(''),
                 new Url('http://another-eula-url.example'),


### PR DESCRIPTION
Turns out, test-integration GH Actions where not triggered on PR's aimed at develop :blush: 

This PR addresses that issue, and fixes the QA issues raised by not running the test-integration on the last couple of PR's that have been merged.

Thanks @VadimSchmitz for noting this issue!