### PR TITLE
Support consent removal in Profile

### DIFF
--- a/assets/css/components/modal-window.scss
+++ b/assets/css/components/modal-window.scss
@@ -64,6 +64,10 @@
   margin-top: calculateRem(45px);
 }
 
+.modalWindowButton {
+  line-height: 2.5rem;
+}
+
 .modalWindow__button {
   height: 3rem;
   padding-bottom: 1rem;

--- a/src/OpenConext/EngineBlockApiClientBundle/Http/JsonApiClient.php
+++ b/src/OpenConext/EngineBlockApiClientBundle/Http/JsonApiClient.php
@@ -131,49 +131,6 @@ class JsonApiClient
     }
 
     /**
-     * @param string $path A URL path, optionally containing printf parameters. The parameters
-     *               will be URL encoded and formatted into the path string.
-     *               Example: "connections/%d.json"
-     * @param array  $parameters
-     * @return mixed $data
-     * @throws InvalidResponseException
-     * @throws MalformedResponseException
-     * @throws ResourceNotFoundException
-     */
-    public function delete($path, array $parameters = [])
-    {
-        $resource = $this->buildResourcePath($path, $parameters);
-
-        $response = $this->httpClient->request('DELETE', $resource, ['exceptions' => false]);
-
-        $statusCode = $response->getStatusCode();
-
-        if ($statusCode === 404) {
-            throw new ResourceNotFoundException(sprintf('Resource "%s" not found', $resource));
-        }
-
-        if ($statusCode !== 200) {
-            throw new InvalidResponseException(
-                sprintf(
-                    'Request to resource "%s" returned an invalid response with status code %s',
-                    $resource,
-                    $statusCode
-                )
-            );
-        }
-
-        try {
-            $data = $this->parseJson((string) $response->getBody());
-        } catch (InvalidArgumentException $e) {
-            throw new MalformedResponseException(
-                sprintf('Cannot read resource "%s": malformed JSON returned', $resource)
-            );
-        }
-
-        return $data;
-    }
-
-    /**
      * @param string $path
      * @param array $parameters
      * @return string

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/delete-button-and-modal.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/delete-button-and-modal.html.twig
@@ -9,7 +9,7 @@
 
 {% set buttonRowContent %}
     <a
-        href="{{ path('profile.my_services_delete', { 'serviceEntityId': deleteId }) }}"
+        href="{{ path('profile.my_services_delete', { 'serviceEntityId': entityId }) }}"
         class="button modalWindow__button"
     >
         {{ 'general.confirm'|trans }}

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/delete-button-and-modal.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/delete-button-and-modal.html.twig
@@ -1,10 +1,11 @@
 {% set modalContent %}
-    <p id="description-part-1-{{ loop.index }}">{{ 'profile.my_connections.delete_connection.explanation'|trans }}</p>
+    <p id="description-part-1-{{ loop.index }}">{{ 'profile.my_connections.delete_connection.explanation'|trans({ '%serviceName%': translatedDisplayName }) }}</p>
     <p id="description-part-2-{{ loop.index }}">{{ 'profile.my_connections.delete_connection.warning'|trans }}</p>
+    <p id="description-part-2-{{ loop.index }}">{{ 'profile.my_services.delete_explanation'|trans }}</p>
 {% endset %}
 
 {% set buttonText %}
-    {{ 'profile.my_services.delete_button'|trans }}<sup>*</sup>
+    {{ 'profile.my_services.delete_button'|trans }}
 {% endset %}
 
 {% set buttonRowContent %}

--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/login-details.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/login-details.html.twig
@@ -37,8 +37,3 @@
         </dd>
     </div>
 </dl>
-{% if global_view_parameters.removeConsentFeatureEnabled and entityId is not empty %}
-    <p id="service__deleteDescription{{ loop.index }}" class="service__deleteDescription">
-        <sup>*</sup> {{ 'profile.my_services.delete_explanation'|trans }}
-    </p>
-{% endif %}

--- a/translations/messages.en.php
+++ b/translations/messages.en.php
@@ -111,7 +111,7 @@ return $overrides + [
             'available_connections' => 'Available Connections',
 
             'delete_connection' => [
-                'explanation' => 'Are you sure you want to delete your connection to ORCID and revoke access to your linked accounts?',
+                'explanation' => 'Are you sure you want to delete your connection to %serviceName% and revoke access to your linked accounts?',
                 'title' => 'Delete Service',
                 'warning' => 'A service might not recognize you the next time you login and all personal data within this service might no longer be available.',
             ],
@@ -183,7 +183,7 @@ return $overrides + [
             'consent_first_used_on' => 'First used on',
             'consent_type' => 'Consent was given by',
             'delete_button' => 'Delete login details',
-            'delete_explanation' => 'deleting these login details means %suiteName% removes this information from your %suiteName% account.  You still have an account at the service itself.  If you want that removed, please do so at the service.',
+            'delete_explanation' => 'Deleting these login details means %suiteName% removes this information from your %suiteName% account.  You still have an account at the service itself.  If you want that removed, please do so at the service.',
             'entity_id' => 'Entity ID',
             'organization_name' => 'Offered by',
             'error_loading_consent' => 'The list of services which you are logged in to cannot be retrieved.',

--- a/translations/messages.nl.php
+++ b/translations/messages.nl.php
@@ -113,7 +113,7 @@ return $overrides + [
             'available_connections' => 'Beschikbare koppelingen',
 
             'delete_connection' => [
-                'explanation' => 'Ben je zeker dat je jouw connectie met ORCID wil verwijderen en de toegang tot je gelinkte accounts wil herroepen?',
+                'explanation' => 'Weet je zeker dat je jouw connectie met %serviceName% wil verwijderen en de toegang tot je gelinkte accounts wil herroepen?',
                 'title' => 'Dienst verwijderen',
                 'warning' => 'Een dienst zal je misschien niet meer herkennen de volgende keer je inlogt, waardoor je geen toegang meer hebt tot je gegevens.',
             ],
@@ -185,7 +185,7 @@ return $overrides + [
             'consent_first_used_on' => 'Voor het eerst gebruikt op',
             'consent_type' => 'Toestemming gegeven door',
             'delete_button' => 'Verwijder login gegevens',
-            'delete_explanation' => 'deze login gegevens verwijderen betekent dat de informatie verwijderd wordt van je %suiteName% account.  Je hebt dan nog steeds een account bij de dienst zelf.  Indien je die ook wil verwijderen moet je dat bij de dienst zelf doen.',
+            'delete_explanation' => 'Deze login gegevens verwijderen betekent dat de informatie verwijderd wordt van je %suiteName% account. Je hebt dan nog steeds een account bij de dienst zelf.  Indien je die ook wil verwijderen moet je dat bij de dienst zelf doen.',
             'entity_id' => 'Entity ID',
             'organization_name' => 'Aangeboden door',
             'error_loading_consent' => 'De lijst met diensten waar je bent ingelogd kan niet opgehaald worden.',

--- a/translations/messages.pt.php
+++ b/translations/messages.pt.php
@@ -112,7 +112,7 @@ return $overrides + [
             'available_connections' => 'Ligações disponíveis',
 
             'delete_connection' => [
-                'explanation' => 'Are you sure you want to delete your unique pseudonymised eduId for ORCID and revoke access to your linked accounts?',
+                'explanation' => 'Are you sure you want to delete your connection to %serviceName% and revoke access to your linked accounts?',
                 'title' => 'Delete Service',
                 'warning' => 'This service might not recognize you the next time you login and all your personal data within this service might be lost.',
             ],
@@ -184,7 +184,7 @@ return $overrides + [
             'consent_first_used_on' => 'Utilizado pela primeira vez em',
             'consent_type' => 'O consentimento foi dado por',
             'delete_button' => 'Apagar detalhes do login',
-            'delete_explanation' => 'excluir esses detalhes de login significa que a %suiteName% remove essas informações da sua conta %suiteName%. Você ainda continua a ter conta no serviço em si. Mas se pretender que seja removido, faça-o no serviço.',
+            'delete_explanation' => 'Excluir esses detalhes de login significa que a %suiteName% remove essas informações da sua conta %suiteName%. Você ainda continua a ter conta no serviço em si. Mas se pretender que seja removido, faça-o no serviço.',
             'entity_id' => 'Entity ID',
             'organization_name' => 'Offered by',
             'error_loading_consent' => 'A lista dos serviços nos quais está autenticado não pode ser apresentada.',


### PR DESCRIPTION
Most of the heavy lifting of this feature was already implemented by @Badlapje. The final integration needed some minor tweaking to get it all to work.

Reminder: use the `remove_consent_enabled` feature flag in config/legacy/parameters.yml to toggle the remove feature.

See: #185 
See: https://www.pivotaltracker.com/story/show/179490276
Requires: https://github.com/OpenConext/OpenConext-engineblock/pull/1160