### PR TITLE
Make the cache path `var/cache/prod` again instead of `var/prod/cache`.

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -50,9 +50,9 @@ class Kernel extends BaseKernel
     {
         // The dev cache lives in the tmp folder of the Docker container
         if ($this->getEnvironment() === 'dev') {
-            return '/tmp/'.$this->environment.'/cache';
+            return '/tmp/cache/'.$this->environment;
         }
-        return dirname(__DIR__).'/var/'.$this->environment.'/cache';
+        return dirname(__DIR__).'/var/cache/'.$this->environment;
     }
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void


### PR DESCRIPTION
The swithed order was introduced in 3.0 but for no apparent reason, since var/cache/<env> is still the default used everywhere, this was likely by mistake (maybe from copying [this example](https://symfony.com/doc/current/configuration/override_dir_structure.html#override-the-cache-directory)?) so change it back so it matches what is customary.