### PR TITLE
Show aggregated attributes even if SP has no IdP-attributes

### DIFF
--- a/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/service-information.html.twig
+++ b/src/OpenConext/ProfileBundle/Resources/views/MyServices/ConsentList/service-information.html.twig
@@ -7,8 +7,9 @@
             {% include '@OpenConextProfile/MyServices/AttributeList/idp.html.twig' %}
         </ul>
     {% endfor %}
+{% endif %}
 
-    {% if specifiedConsent.getAttributeAggregatedAttributes is not empty %}
+{% if specifiedConsent.getAttributeAggregatedAttributes is not empty %}
 
     <p>{{ 'profile.my_services.service_information.aa_text'|trans }}</p>
 
@@ -23,6 +24,4 @@
         <p>{{ 'profile.table.explanation.text'|trans({'%singularOrPlural%': singularOrPlural }) }}</p>
     </li>
     </ul>
-    {% endif %}
 {% endif %}
-


### PR DESCRIPTION
The first `if` in the template checks if the user has any IdP released attributes, and only then displays those _and_ the aggregated attributes. It is however possible (though not common) that a service has an empty list of IdP attributes but does get info from other sources. So move the aggregation block outside of the if.