### PR TITLE
GHA: Add package write permissions to the docker build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    permissions:
+      packages: write
     steps:
 
     - name: Check out the repo


### PR DESCRIPTION
This adds packages:write permissions to the workflow that builds and publishes the docker image. 