### PR TITLE
When sorting SPs by name, do so case insentively

### DIFF
--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -434,7 +434,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Traversable\\<mixed, mixed\\>\\:\\:getArrayCopy\\(\\)\\.$#"
-			count: 2
+			count: 3
 			path: ../../src/OpenConext/Profile/Tests/Value/SpecifiedConsentListTest.php
 
 		-

--- a/src/OpenConext/Kernel.php
+++ b/src/OpenConext/Kernel.php
@@ -40,6 +40,4 @@ class Kernel extends BaseKernel
     {
         return $this->getCacheDir();
     }
-
-
 }

--- a/src/OpenConext/Profile/Tests/Value/SpecifiedConsentListTest.php
+++ b/src/OpenConext/Profile/Tests/Value/SpecifiedConsentListTest.php
@@ -45,6 +45,22 @@ class SpecifiedConsentListTest extends TestCase
         $this->assertEquals('C-service', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
     }
 
+    public function test_it_can_order_by_display_name_of_sp_case_insensitively(): void
+    {
+        $locale = 'en';
+        $specifiedConsent = [
+            $this->buildMockSpecifiedConsent($locale, 'C-service'),
+            $this->buildMockSpecifiedConsent($locale, 'A-service'),
+            $this->buildMockSpecifiedConsent($locale, 'b-service'),
+        ];
+        $list = SpecifiedConsentList::createWith($specifiedConsent);
+        $list->sortByDisplayName('en');
+        $sorted = $list->getIterator()->getArrayCopy();
+        $this->assertEquals('A-service', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+        $this->assertEquals('b-service', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+        $this->assertEquals('C-service', array_shift($sorted)->getServiceProvider()->getLocaleAwareEntityName($locale));
+    }
+
     /**
      * The entities with a display name are sorted on top of the list, followed by the ones with only an entityID.
      * Both lists are sorted alphabetically.

--- a/src/OpenConext/Profile/Value/SpecifiedConsentList.php
+++ b/src/OpenConext/Profile/Value/SpecifiedConsentList.php
@@ -69,8 +69,8 @@ final class SpecifiedConsentList implements IteratorAggregate, Countable
                 $sortedByEntityId[$displayName] = $consent;
             }
         }
-        ksort($sorted, SORT_STRING);
-        ksort($sortedByEntityId, SORT_STRING);
+        ksort($sorted, SORT_STRING|SORT_FLAG_CASE);
+        ksort($sortedByEntityId, SORT_STRING|SORT_FLAG_CASE);
         $this->specifiedConsents = $sorted +  $sortedByEntityId;
     }
     private function initializeWith(


### PR DESCRIPTION
So you can find the service "iotroam" near "Internal Gitlab" and not after the "Z".