### PR TITLE
Add ARP santizer

### DIFF
--- a/src/OpenConext/Profile/Tests/Value/ArpTest.php
+++ b/src/OpenConext/Profile/Tests/Value/ArpTest.php
@@ -97,7 +97,7 @@ class ArpTest extends TestCase
         }
     }
 
-    public function test_that_sanitized_arp_data_only_have_the_allowed_keys()
+    public function test_that_sanitized_arp_data_only_have_the_allowed_keys(): void
     {
         $input = ['urn:mace:terena.org:attribute-def:schacHomeOrganization' => [[
             'invalid-key' => 'foo',

--- a/src/OpenConext/Profile/Tests/Value/ArpTest.php
+++ b/src/OpenConext/Profile/Tests/Value/ArpTest.php
@@ -27,6 +27,7 @@ use stdClass;
 use Surfnet\SamlBundle\SAML2\Attribute\Attribute;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use function PHPUnit\Framework\assertTrue;
 
 class ArpTest extends TestCase
 {
@@ -94,6 +95,31 @@ class ArpTest extends TestCase
         foreach ($arp->getAttributesGroupedBySource()['idp'] as $attribute) {
             $this->assertEquals($bogusDefinition, $attribute->getAttributeDefinition());
         }
+    }
+
+    public function test_that_sanitized_arp_data_only_have_the_allowed_keys()
+    {
+        $input = ['urn:mace:terena.org:attribute-def:schacHomeOrganization' => [[
+            'invalid-key' => 'foo',
+            'value' => '*',
+            'source' => 'voot',
+            'motivation' => 'foo',
+            'test' => true,
+        ]]];
+
+        $expected = [
+            "value" => "*",
+            "source" => "voot",
+            "motivation" => "foo",
+          ];
+
+        $arp = Arp::createWith($input);
+
+
+        $this->assertTrue(
+            $expected === $arp->getAttributesGroupedBySource()[$expected['source']][0]->getValue()[0]
+        );
+
     }
 
     public function invalidArpData(): array

--- a/src/OpenConext/Profile/Tests/fixture/arp-response.json
+++ b/src/OpenConext/Profile/Tests/fixture/arp-response.json
@@ -59,18 +59,13 @@
   ],
   "urn:mace:dir:attribute-def:uid": [
     {
-      "value": "*"
+      "value": "*",
+      "motivation": "my-motivation"
     }
   ],
   "urn:mace:dir:attribute-def:preferredLanguage": [
     {
-      "value": "*"
-    }
-  ],
-  "urn:mace:dir:attribute-def:eduPersonAffiliation": [
-    {
-      "value": "filter-value",
-      "source": "voot",
+      "value": "*",
       "use_as_name_id": false
     }
   ]

--- a/src/OpenConext/Profile/Tests/fixture/arp-response.json
+++ b/src/OpenConext/Profile/Tests/fixture/arp-response.json
@@ -66,5 +66,12 @@
     {
       "value": "*"
     }
+  ],
+  "urn:mace:dir:attribute-def:eduPersonAffiliation": [
+    {
+      "value": "filter-value",
+      "source": "voot",
+      "use_as_name_id": false
+    }
   ]
 }

--- a/src/OpenConext/Profile/Value/Arp.php
+++ b/src/OpenConext/Profile/Value/Arp.php
@@ -40,11 +40,12 @@ final class Arp
         array $arp,
         AttributeDictionary $dictionary = null,
     ): self {
+
+        $arp = self::sanitizeARPData($arp);
+
         // Input validation
         foreach ($arp as $attributeInformation) {
-            if (!is_array($attributeInformation)) {
-                throw new InvalidArpDataException('The attribute information in the arp should be an array.');
-            }
+
             if (!self::isValidAttribute($attributeInformation)) {
                 throw new InvalidArpDataException('The attribute information is formatted invalidly.');
             }
@@ -185,5 +186,41 @@ final class Arp
             }
         }
         return '';
+    }
+
+    /**
+     * Accordingly to https://www.pivotaltracker.com/n/projects/1453004/stories/187607790
+     * the ARP data should only contain the following keys: value, source, motivation.
+     * This function will filter out all other keys, which are to be ignored.
+     */
+    private static function sanitizeARPData(array $arp): array
+    {
+        $validKeys = ['value', 'source', 'motivation'];
+
+        $sanitizedArp = [];
+        foreach ($arp as $attributeName => $attributeInformation) {
+            if (!is_array($attributeInformation)) {
+                throw new InvalidArpDataException('The attribute information in the arp should be an array.');
+            }
+
+            $sanitizedAttributeInformation = [];
+            foreach ($attributeInformation as $attributeInformationEntry) {
+                if (!is_array($attributeInformationEntry)) {
+                    continue;
+                }
+
+                $sanitizedAttributeInformation[] = array_filter(
+                    $attributeInformationEntry,
+                    function ($key) use ($validKeys) {
+                        return in_array($key, $validKeys);
+                    },
+                    ARRAY_FILTER_USE_KEY
+                );
+            }
+
+            $sanitizedArp[$attributeName] = $sanitizedAttributeInformation;
+        }
+
+        return $sanitizedArp;
     }
 }

--- a/src/OpenConext/Profile/Value/Arp.php
+++ b/src/OpenConext/Profile/Value/Arp.php
@@ -45,7 +45,6 @@ final class Arp
 
         // Input validation
         foreach ($arp as $attributeInformation) {
-
             if (!self::isValidAttribute($attributeInformation)) {
                 throw new InvalidArpDataException('The attribute information is formatted invalidly.');
             }
@@ -193,8 +192,9 @@ final class Arp
      * the ARP data should only contain the following keys: value, source, motivation.
      * This function will filter out all other keys, which are to be ignored.
      */
-    private static function sanitizeARPData(array $arp): array
-    {
+    private static function sanitizeARPData(
+        array $arp,
+    ): array {
         $validKeys = ['value', 'source', 'motivation'];
 
         $sanitizedArp = [];
@@ -214,7 +214,7 @@ final class Arp
                     function ($key) use ($validKeys) {
                         return in_array($key, $validKeys);
                     },
-                    ARRAY_FILTER_USE_KEY
+                    ARRAY_FILTER_USE_KEY,
                 );
             }
 

--- a/src/OpenConext/Profile/Value/Arp.php
+++ b/src/OpenConext/Profile/Value/Arp.php
@@ -41,7 +41,7 @@ final class Arp
         AttributeDictionary $dictionary = null,
     ): self {
 
-        $arp = self::sanitizeARPData($arp);
+        $arp = self::sanitizeArpData($arp);
 
         // Input validation
         foreach ($arp as $attributeInformation) {

--- a/src/OpenConext/Profile/Value/Arp.php
+++ b/src/OpenConext/Profile/Value/Arp.php
@@ -191,10 +191,14 @@ final class Arp
      * Accordingly to https://www.pivotaltracker.com/n/projects/1453004/stories/187607790
      * the ARP data should only contain the following keys: value, source, motivation.
      * This function will filter out all other keys, which are to be ignored.
+     *
+     * @param array<string, array<array<string, string>>> $arp
+     * @return array<string, array<array<string, string>>>
      */
     private static function sanitizeARPData(
         array $arp,
     ): array {
+
         $validKeys = ['value', 'source', 'motivation'];
 
         $sanitizedArp = [];

--- a/src/OpenConext/Profile/Value/Arp.php
+++ b/src/OpenConext/Profile/Value/Arp.php
@@ -195,7 +195,7 @@ final class Arp
      * @param array<string, array<array<string, string>>> $arp
      * @return array<string, array<array<string, string>>>
      */
-    private static function sanitizeARPData(
+    private static function sanitizeArpData(
         array $arp,
     ): array {
 


### PR DESCRIPTION
Added a local function to remove al irrelevant attributes from the ARP returned from the API calls. This way, the API can "grow" without erroring the Arp class