### PR TITLE
Set ignore_unknown_attributes to true

### DIFF
--- a/config/packages/surfnet_saml.yaml
+++ b/config/packages/surfnet_saml.yaml
@@ -4,6 +4,8 @@ parameters:
 surfnet_saml:
   enable_authentication: true
   hosted:
+    attribute_dictionary:
+      ignore_unknown_attributes: true
     service_provider:
       enabled: true
       assertion_consumer_route: profile.saml_consume_assertion


### PR DESCRIPTION
This value has to be set, otherwise the service is initiated with NULL (which fails typing)

Other possible improvements:
- Config the service with false in the `src/Resources/config/services.yaml` 
- Type the `$ignoreUnkonwnAttributes` variable as bool in the constructor of AttributeDictionary