### PR TITLE
Deprecation of https://github.com/actions/cache < v3

### DIFF
--- a/.github/workflows/daily-security-check.yml
+++ b/.github/workflows/daily-security-check.yml
@@ -78,7 +78,7 @@ jobs:
           cache: 'maven'
       - name: Set up maven cache if needed
         if: steps.check_maven.outputs.files_exists == 'true'
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
See https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/